### PR TITLE
Fixed the insertion of complex LaTeX (Bug #43):

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,8 @@
 --v0.7.1
 
 - Fixed the insertion of complex LaTeX.
+- Select the insertion marker when opening the insert complex LaTeX dialog.
+- Cleaned up the options dialog.
 
 --v0.7
 

--- a/Changelog
+++ b/Changelog
@@ -3,6 +3,8 @@
 - Fixed the insertion of complex LaTeX.
 - Select the insertion marker when opening the insert complex LaTeX dialog.
 - Cleaned up the options dialog.
+- Replaced place holder __REPLACEME__ with __REPLACE_ME__, which IMHO is easier
+  to the eye.
 
 --v0.7
 

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+--v0.7.1
+
+- Fixed the insertion of complex LaTeX.
+
 --v0.7
 
 - Use latex/dvipng instead of latex/dvips/convert to generate the image file.

--- a/content/help.html
+++ b/content/help.html
@@ -19,7 +19,7 @@
 \usepackage[utf8x]{inputenc}
 \pagestyle{empty}
 \begin{document}
-__REPLACEME__ %this is where your LaTeX expression goes
+__REPLACE_ME__ %this is where your LaTeX expression goes
 \end{document}
     </pre>
    <p>
@@ -29,7 +29,7 @@ __REPLACEME__ %this is where your LaTeX expression goes
     extra output such as page numbers, which is why cropping works.
     </p>
     <p>
-    The <tt>__REPLACEME__</tt> word will be replaced with the LaTeX expression
+    The <tt>__REPLACE_ME__</tt> word will be replaced with the LaTeX expression
     you specified. Therefore, it is important you put it in the right place.
     </p>
     <p>
@@ -52,7 +52,7 @@ __REPLACEME__ %this is where your LaTeX expression goes
 \usepackage{mathpazo}
 \pagestyle{empty}
 \begin{document}
-__REPLACEME__ %this is where your LaTeX expression goes
+__REPLACE_ME__ %this is where your LaTeX expression goes
 \end{document}
     </pre>
  

--- a/content/insert.js
+++ b/content/insert.js
@@ -4,7 +4,7 @@ function on_ok() {
 }
 
 window.addEventListener("load", function (event) {
-  var marker = "__REPLACEME__";
+  var marker = "__REPLACE_ME__";
   var textarea = document.getElementById("tblatex-expr");
   textarea.value = window.arguments[1];
   var start = textarea.value.indexOf(marker);

--- a/content/insert.js
+++ b/content/insert.js
@@ -3,10 +3,6 @@ function on_ok() {
   window.arguments[0](latex);
 }
 
-function on_cancel() {
-  window.close();
-}
-
 window.addEventListener("load", function (event) {
   document.getElementById("tblatex-expr").value = window.arguments[1];
 }, false);

--- a/content/insert.js
+++ b/content/insert.js
@@ -4,7 +4,13 @@ function on_ok() {
 }
 
 window.addEventListener("load", function (event) {
-  document.getElementById("tblatex-expr").value = window.arguments[1];
+  var marker = "__REPLACEME__";
+  var textarea = document.getElementById("tblatex-expr");
+  textarea.value = window.arguments[1];
+  var start = textarea.value.indexOf(marker);
+  textarea.focus();
+  if (start > -1)
+    textarea.setSelectionRange(start, start+marker.length);
 }, false);
 
 var prefs = Components.classes["@mozilla.org/preferences-service;1"]

--- a/content/insert.xul
+++ b/content/insert.xul
@@ -5,11 +5,8 @@
   title="Insert a LaTeX expression"
   xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
   xmlns:html="http://www.w3.org/1999/xhtml"
-  buttons="accept,cancel"
-  buttonlabelcancel="Cancel"
-  buttonlabelaccept="Ok"
-  ondialogaccept="return on_ok();"
-  ondialogcancel="return on_cancel();">
+  buttons="cancel"
+  buttonlabelcancel="Quit">
   <script type="application/javascript" src="chrome://tblatex/content/insert.js" />
     
     <dialogheader title="Latex It!" description="Insert a complex LaTeX expression"/>
@@ -20,6 +17,7 @@
       <hbox>
         <button label="Load default template" oncommand="on_reset();" />
         <spacer flex="1" />
+        <button label="Insert at cursor position" oncommand="on_ok();" />
       </hbox>
    </groupbox>
 </dialog>

--- a/content/insert.xul
+++ b/content/insert.xul
@@ -6,7 +6,7 @@
   xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
   xmlns:html="http://www.w3.org/1999/xhtml"
   buttons="cancel"
-  buttonlabelcancel="Quit">
+  buttonlabelcancel="Close">
   <script type="application/javascript" src="chrome://tblatex/content/insert.js" />
     
     <dialogheader title="Latex It!" description="Insert a complex LaTeX expression"/>

--- a/content/main.js
+++ b/content/main.js
@@ -303,7 +303,7 @@ var tblatex = {
       var elt = nodes[i];
       if (!silent)
         write_log("*** Found expression "+elt.nodeValue+"\n");
-      var latex_expr = replace(template, "__REPLACEME__", elt.nodeValue);
+      var latex_expr = replace(template, "__REPLACE_ME__", elt.nodeValue);
       var [st, url, log] = run_latex(latex_expr, silent);
       if (st || !silent)
         write_log(log);

--- a/content/main.js
+++ b/content/main.js
@@ -309,7 +309,7 @@ var tblatex = {
         write_log(log);
       if (st == 0 || st == 1) {
         if (debug)
-          write_log("--> Adding at cursor position... ");
+          write_log("--> Replacing node... ");
         var img = editor.createElementWithDefaults("img");
         var reader = new FileReader();
         var xhr = new XMLHttpRequest();
@@ -413,7 +413,7 @@ var tblatex = {
         write_log(log);
         if (st == 0 || st == 1) {
           if (debug)
-            write_log("--> Replacing node... ");
+            write_log("--> Inserting at cursor position... ");
           var img = editor.createElementWithDefaults("img");
           var reader = new FileReader();
           var xhr = new XMLHttpRequest();

--- a/content/main.js
+++ b/content/main.js
@@ -309,7 +309,7 @@ var tblatex = {
         write_log(log);
       if (st == 0 || st == 1) {
         if (debug)
-          write_log("--> Replacing node... ");
+          write_log("--> Adding at cursor position... ");
         var img = editor.createElementWithDefaults("img");
         var reader = new FileReader();
         var xhr = new XMLHttpRequest();
@@ -402,6 +402,7 @@ var tblatex = {
   tblatex.on_insert_complex = function (event) {
     var editor = GetCurrentEditor();
     var f = function (latex_expr) {
+      var debug = prefs.getBoolPref("debug");
       g_complex_input = latex_expr;
       editor.beginTransaction();
       try {
@@ -411,6 +412,8 @@ var tblatex = {
         log = log || "Everything went OK.\n";
         write_log(log);
         if (st == 0 || st == 1) {
+          if (debug)
+            write_log("--> Replacing node... ");
           var img = editor.createElementWithDefaults("img");
           var reader = new FileReader();
           var xhr = new XMLHttpRequest();
@@ -423,18 +426,23 @@ var tblatex = {
             editor.insertElementAtSelection(img, true);
 
             img.alt = latex_expr;
-            img.title = latex_expr;
             img.style = "vertical-align: middle";
             img.src = reader.result;
 
             push_undo_func(function () {
               img.parentNode.removeChild(img);
             });
+            if (debug)
+              write_log("done\n");
           }, false);
 
           xhr.open('GET',"file://"+url);
           xhr.responseType = 'blob';
+          xhr.overrideMimeType("image/png");
           xhr.send();
+        } else {
+          if (debug)
+            write_log("--> Failed, not inserting\n");
         }
       } catch (e) {
         Components.utils.reportError("TBLatex Error (while inserting) "+e);
@@ -443,7 +451,7 @@ var tblatex = {
       editor.endTransaction();
     };
     var template = g_complex_input || prefs.getCharPref("template");
-    window.openDialog("chrome://tblatex/content/insert.xul", "", "chrome", f, template);
+    window.openDialog("chrome://tblatex/content/insert.xul", "", "chrome, resizable=yes", f, template);
     event.stopPropagation();
   };
 

--- a/content/options.xul
+++ b/content/options.xul
@@ -51,7 +51,7 @@
         onclick="window.openDialog('chrome://tblatex/content/help.html', '',
           'all,chrome,dialog=no,status,toolbar,width=640,height=480');" />
     </hbox>
-    <label value="Use __REPLACEME__ as a place marker, if you want to have it automatically highlighted." />
+    <label value="Use __REPLACE_ME__ as a place marker, if you want to have it automatically highlighted." />
     <html:textarea preference="tblatex.template" id="template_textbox" multiline="true"
       rows="12" />
   </groupbox>

--- a/content/options.xul
+++ b/content/options.xul
@@ -10,7 +10,8 @@
 >
   <script type="application/javascript" src="chrome://tblatex/content/options.js" />
  
-  <vbox>
+  <groupbox>
+    <label value="Executables:" style="header; font-weight: bold;" />
     <hbox>
       <label control="latex_textbox" value="Path to latex executable" />
       <textbox preference="tblatex.latex_path" id="latex_textbox" />
@@ -21,36 +22,39 @@
       <textbox preference="tblatex.dvipng_path" id="dvipng_textbox" />
       <button label="Browse..." oncommand="pick_file(document.getElementsByTagName('textbox')[1], 'dvipng');" />
     </hbox>
+    <label style="text-decoration: underline; color: navy; cursor: pointer" value="Open the autodetection dialog"
+      onclick="open_autodetect();" />
+  </groupbox>
+  <separator />
+  <groupbox>
+    <label value="Configurations:" style="header; font-weight: bold;" />
     <hbox>
       <label control="dpi_textbox" value="Resolution (dpi)" />
       <textbox preference="tblatex.dpi" id="dpi_textbox" />
-      <spacer />
     </hbox>
     <hbox>
       <label control="log_checkbox" value="Generate a log report" />
       <checkbox preference="tblatex.log" id="log_checkbox" />
-      <spacer />
     </hbox>
     <hbox>
       <label control="debug_checkbox" value="Generate debug info" />
       <checkbox preference="tblatex.debug" id="debug_checkbox" />
-      <spacer />
     </hbox>
-    <label style="text-decoration: underline; color: navy; margin-top: 2em;
-      cursor: pointer" value="Open the autodetection dialog"
-      onclick="open_autodetect();" />
-  </vbox>
-  
-  <vbox>
+  </groupbox>
+  <separator />
+  <groupbox>
+    <label value="Template:" style="header; font-weight: bold;" />
     <hbox>
-      <label control="template_textbox" value="Template to use to generate LaTeX parts "/>
+      <label control="template_textbox" value="Template to use to generate LaTeX parts."/>
+      <spacer flex="1" />
       <label style="text-decoration: underline; color: navy; cursor: pointer" value="Help ?"
         onclick="window.openDialog('chrome://tblatex/content/help.html', '',
           'all,chrome,dialog=no,status,toolbar,width=640,height=480');" />
     </hbox>
+    <label value="Use __REPLACEME__ as a place marker, if you want to have it automatically highlighted." />
     <html:textarea preference="tblatex.template" id="template_textbox" multiline="true"
       rows="12" />
-  </vbox>
+  </groupbox>
 
   <script
      src="chrome://global/content/preferencesBindings.js"

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -3,6 +3,6 @@ pref("tblatex.dvipng_path", "");
 pref("tblatex.dpi", 150);
 pref("tblatex.log", true);
 pref("tblatex.debug", false);
-pref("tblatex.template", "\\documentclass{article}\n\\usepackage[utf8x]{inputenc}\n\\pagestyle{empty}\n\\begin{document}\n__REPLACEME__ %this is where your LaTeX expression goes\n\\end{document}\n");
+pref("tblatex.template", "\\documentclass{article}\n\\usepackage[utf8x]{inputenc}\n\\pagestyle{empty}\n\\begin{document}\n__REPLACE_ME__ %this is where your LaTeX expression goes\n\\end{document}\n");
 pref("tblatex.firstrun", 0);
 

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
   "author": "Jonathan Protzenko",
   "name": "LaTeX It!",
   "description": "Automatically change $\\LaTeX$ into images in your HTML mails.",
-  "version": "0.6.8",
+  "version": "0.7.1",
   "homepage_url": "https://github.com/protz/LatexIt/wiki",
   "legacy": true
 }


### PR DESCRIPTION
1. Got the dialog to work. The problem was, that neither the stock `Ok` nor the
   stock `Cancel` button called the call-back method. Added a new "Insert" button
   and removed the callback method for the `Cancel` button.
2. Added debug message to the insertion code.
3. Added `xhr.overrideMimeType("image/png");` to extended LaTeX (https://github.com/indigestion/LatexIt/commit/0164e1deb3ff3bd882aae87c0199bf5b4787e6ff only added it to pictures generated from an inline LaTeX).
4. Removed `img.title`.
5. Made the dialog resizeable.
6. Select the marker on opening the insertion dialog (commit https://github.com/protz/LatexIt/pull/46/commits/eba432cc69c28cb20793a1188c632c51d4e3328b).
7. Cleaned up the configuration dialog (commit https://github.com/protz/LatexIt/pull/46/commits/eba432cc69c28cb20793a1188c632c51d4e3328b).
8. Replaces the marker `__REPLACEME__` with `__REPLACE_ME__` which IMHO is easier to spot (commit https://github.com/protz/LatexIt/pull/46/commits/5a7842291c24e6b4335a80e208aa338abfcb274e).