### PR TITLE
Added alignment of baseline in LaTeX bitmap at baseline of text in mail message

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+--v0.7.1
+
+- Added alignment of inserted pictures to the text baseline.
+
 --v0.7
 
 - Use latex/dvipng instead of latex/dvips/convert to generate the image file.

--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,7 @@
 --v0.7.1
 
 - Added alignment of inserted pictures to the text baseline.
+- Updated the help file.
 
 --v0.7
 

--- a/content/help.html
+++ b/content/help.html
@@ -17,6 +17,7 @@
     <pre>
 \documentclass{article}
 \usepackage[utf8x]{inputenc}
+\usepackage[active,displaymath,textmath]{preview}
 \pagestyle{empty}
 \begin{document}
 __REPLACEME__ %this is where your LaTeX expression goes
@@ -46,6 +47,7 @@ __REPLACEME__ %this is where your LaTeX expression goes
     <pre>
 \documentclass{article}
 \usepackage[utf8x]{inputenc}
+\usepackage[active,displaymath,textmath]{preview}
 \usepackage{amsmath,amssymb,amsopn}
 \usepackage{mathrsfs}
 \usepackage{palatino}

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -3,6 +3,6 @@ pref("tblatex.dvipng_path", "");
 pref("tblatex.dpi", 150);
 pref("tblatex.log", true);
 pref("tblatex.debug", false);
-pref("tblatex.template", "\\documentclass{article}\n\\usepackage[utf8x]{inputenc}\n\\pagestyle{empty}\n\\begin{document}\n__REPLACEME__ %this is where your LaTeX expression goes\n\\end{document}\n");
+pref("tblatex.template", "\\documentclass{article}\n\\usepackage[utf8x]{inputenc}\n\\usepackage[active,displaymath,textmath]{preview}\n\\pagestyle{empty}\n\\begin{document}\n__REPLACEME__ %this is where your LaTeX expression goes\n\\end{document}\n");
 pref("tblatex.firstrun", 0);
 

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
   "author": "Jonathan Protzenko",
   "name": "LaTeX It!",
   "description": "Automatically change $\\LaTeX$ into images in your HTML mails.",
-  "version": "0.6.8",
+  "version": "0.7.1",
   "homepage_url": "https://github.com/protz/LatexIt/wiki",
   "legacy": true
 }


### PR DESCRIPTION
This should deal with #36.

Note, it is only tested on a Linux system, but neither on MacOS nor Windows!

I also changed the message which is displayed, if `LaTeXIt!` is run on a plain text message, because sadly it is not possible anymore to switch from a plain text message to a HTML message.

BTW the LaTeXIt! toolbar button actually should be grayed out if in a plain text message. And to be honest, there should be a menu entry for those not using the button bar. But that is another story ... (That is now dealt in PR #50.)