### PR TITLE
Added improvements to the LaTeXIt! button. a context menu to the composer window and preferences to Add-ons menu

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -4,6 +4,7 @@
   - Button is disabled for plain text composer windows.
   - Middle click calls 'undo'.
   - Shift+middle click callse 'undo_all'.
+- Added context menu to composer window.
 
 --v0.7
 

--- a/Changelog
+++ b/Changelog
@@ -5,6 +5,8 @@
   - Middle click calls 'undo'.
   - Shift+middle click callse 'undo_all'.
 - Added context menu to composer window.
+- Added LaTeXIt! to the Add-ons menu to access the preferences:
+  - Removed the configuration item from toolbar and context menues.
 
 --v0.7
 

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,10 @@
+--v0.7.1
+
+- Added improvements of LaTeXIt! button:
+  - Button is disabled for plain text composer windows.
+  - Middle click calls 'undo'.
+  - Shift+middle click callse 'undo_all'.
+
 --v0.7
 
 - Use latex/dvipng instead of latex/dvips/convert to generate the image file.

--- a/content/main.js
+++ b/content/main.js
@@ -470,10 +470,10 @@ var tblatex = {
     event.stopPropagation();
   };
 
-  tblatex.on_open_options = function (event) {
-    window.openDialog("chrome://tblatex/content/options.xul", "", "");
-    event.stopPropagation();
-  };
+//  tblatex.on_open_options = function (event) {
+//    window.openDialog("chrome://tblatex/content/options.xul", "", "");
+//    event.stopPropagation();
+//  };
 
   /* Is this even remotey useful ? */
   /* Yes, because we can disable the toolbar button and menu items for plain text messages! */
@@ -490,7 +490,7 @@ var tblatex = {
           btn.tooltipText = "Start a message in HTML format (by holding the 'Shift' key) to be able to turn every $...$ into a LaTeX image"
           btn.disabled = true;
         }
-        for (var id of ["tblatex-context", "tblatex-context-undo", "tblatex-context-undo_all", "tblatex-context-insert_complex"]) {
+        for (var id of ["tblatex-context", "tblatex-context-menu"]) {
             var menu = document.getElementById(id);
             if (menu)
                 menu.disabled = true;

--- a/content/main.js
+++ b/content/main.js
@@ -371,8 +371,8 @@ var tblatex = {
   };
 
   tblatex.on_middleclick = function(event) {
-    // Return on right button
-    if (event.button == 2) return;
+    // Return on all but the middle button
+    if (event.button != 1) return;
 
     if (event.shiftKey) {
       // Undo all

--- a/content/main.js
+++ b/content/main.js
@@ -476,21 +476,24 @@ var tblatex = {
   };
 
   /* Is this even remotey useful ? */
-  /* Yes, because we can disable the toolbar button for plain text messages! */
+  /* Yes, because we can disable the toolbar button and menu items for plain text messages! */
   window.addEventListener("load",
     function () {
       var tb = document.getElementById("composeToolbar2");
       tb.setAttribute("defaultset", tb.getAttribute("defaultset")+",tblatex-button-1");
 
-      // Disable the button for non-html composer windows
+      // Disable the button and menu for non-html composer windows
+      var editor_elt = document.getElementById("content-frame");
+      if (editor_elt.editortype != "htmlmail") {
       var btn = document.getElementById("tblatex-button-1");
       if (btn) {
-        var editor_elt = document.getElementById("content-frame");
-        if (editor_elt.editortype != "htmlmail") {
           btn.tooltipText = "Start a message in HTML format (by holding the 'Shift' key) to be able to turn every $...$ into a LaTeX image"
           btn.disabled = true;
-        } else {
-          btn.disabled = false;
+        }
+        for (var id of ["tblatex-context", "tblatex-context-undo", "tblatex-context-undo_all", "tblatex-context-insert_complex"]) {
+            var menu = document.getElementById(id);
+            if (menu)
+                menu.disabled = true;
         }
       }
     }, false);

--- a/content/overlay.xul
+++ b/content/overlay.xul
@@ -10,7 +10,7 @@
       />
   </keyset>
   <popup id="msgComposeContext">
-    <menuseparator/>
+    <menuseparator />
     <menuitem id="tblatex-context"
       label="LaTeX It!"
       class="menuitem-iconic"
@@ -24,12 +24,13 @@
         <menuitem id="tblatex-context-undo_all"
           label="Undo All"
           oncommand="tblatex.on_undo_all(event);" />
+        <menuseparator />
         <menuitem id="tblatex-context-insert_complex"
           label="Insert complex LaTeX"
           oncommand="tblatex.on_insert_complex(event);" />
       </menupopup>
     </menu>
-    <menuseparator/>
+    <menuseparator />
   </popup>
   <toolbarpalette id="MsgComposeToolbarPalette">
     <toolbarbutton id="tblatex-button-1"

--- a/content/overlay.xul
+++ b/content/overlay.xul
@@ -13,9 +13,10 @@
     <toolbarbutton id="tblatex-button-1"
       class="toolbarbutton-1"
       label="Latex It!"
-      tooltiptext="Turn every $$ into a LaTeX image (Ctrl/Meta-Shift-L for silent run)"
+      tooltiptext="Turn every $...$ into a LaTeX image (Ctrl/Meta-Shift-L for silent run)"
       type="menu-button"
       oncommand="tblatex.on_latexit(event, false);"
+      onclick="tblatex.on_middleclick(event);"
       >
       <menupopup>
         <menuitem label="Undo" id="tblatex-button-undo"

--- a/content/overlay.xul
+++ b/content/overlay.xul
@@ -9,6 +9,32 @@
       oncommand="tblatex.on_latexit(event, true);"
       />
   </keyset>
+  <popup id="msgComposeContext">
+    <menuseparator/>
+    <menuitem id="tblatex-context"
+      label="LaTeX It!"
+      class="menuitem-iconic"
+      oncommand="tblatex.on_latexit(event, false);" />
+    <menu id="tblatex-context-menu"
+      label="More LaTeX It!">
+      <menupopup id="tblatex-context-popup">
+        <menuitem id="tblatex-context-undo"
+          label="Undo"
+          oncommand="tblatex.on_undo(event);" />
+        <menuitem id="tblatex-context-undo_all"
+          label="Undo All"
+          oncommand="tblatex.on_undo_all(event);" />
+        <menuitem id="tblatex-context-insert_complex"
+          label="Insert complex LaTeX"
+          oncommand="tblatex.on_insert_complex(event);" />
+        <menuseparator/>
+        <menuitem id="tblatex-context-open_options"
+          label="Options"
+          oncommand="tblatex.on_open_options(event);" />
+      </menupopup>
+    </menu>
+    <menuseparator/>
+  </popup>
   <toolbarpalette id="MsgComposeToolbarPalette">
     <toolbarbutton id="tblatex-button-1"
       class="toolbarbutton-1"

--- a/content/overlay.xul
+++ b/content/overlay.xul
@@ -27,10 +27,6 @@
         <menuitem id="tblatex-context-insert_complex"
           label="Insert complex LaTeX"
           oncommand="tblatex.on_insert_complex(event);" />
-        <menuseparator/>
-        <menuitem id="tblatex-context-open_options"
-          label="Options"
-          oncommand="tblatex.on_open_options(event);" />
       </menupopup>
     </menu>
     <menuseparator/>
@@ -57,11 +53,6 @@
         <menuitem label="Insert complex LaTeX" id="tblatex-button-insert_complex"
           oncommand="tblatex.on_insert_complex(event);"
           tooltiptext="Open a dialog to insert an arbitrary chunk of LaTeX"
-          />
-        <menuseparator />
-        <menuitem label="Options" id="tblatex-button-open_options"
-          oncommand="tblatex.on_open_options(event);"
-          tooltiptext="Open the options dialog"
           />
       </menupopup>
     </toolbarbutton>

--- a/manifest.json
+++ b/manifest.json
@@ -11,5 +11,12 @@
   "description": "Automatically change $\\LaTeX$ into images in your HTML mails.",
   "version": "0.7.1",
   "homepage_url": "https://github.com/protz/LatexIt/wiki",
-  "legacy": true
+  "legacy": {
+    "type": "xul",
+    "options": {
+      "page": "chrome://tblatex/content/options.xul",
+      "open_in_tab": false
+    }
+  }
 }
+

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
   "author": "Jonathan Protzenko",
   "name": "LaTeX It!",
   "description": "Automatically change $\\LaTeX$ into images in your HTML mails.",
-  "version": "0.6.8",
+  "version": "0.7.1",
   "homepage_url": "https://github.com/protz/LatexIt/wiki",
   "legacy": true
 }


### PR DESCRIPTION
The following improvements were implemented:

- Disable button for plain text message composers (closes #48).
- Middle click calls 'undo' (closes #2).
- Shift+middle click calls 'undo_all'.

The second commit https://github.com/protz/LatexIt/pull/50/commits/7b7f0270473e5d4cc399b9388b80496a43e61bb8 adds a context menu to the composer window (closes #49).

The third commit https://github.com/protz/LatexIt/pull/50/commits/e3b82a2a819890013c9a20d5f126e50fb402b228 adds LaTeXIt to the `Add-ons` menu to get to the preferences from a common place (closes #42).