### PR TITLE
Autoscaling of images to fit the font size

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,12 +1,11 @@
 --v0.7.1
 
--- Changed 'resolution' to 'px' (font height).
-- Insert image in font size of surrounding text (if the 'autodpi'
-  configuration is set, otherwise in the configured font height).
-- When inserting complex LaTeX, the size can be automatically set
-  to the font size of the surrounding text or to a manually set
-  font size.
-- Beautified preferences dialog.
+- Added autoscaling of images to font size (can be switched off in the
+  preferences, where a size can be manually set).
+- When inserting a complex LaTeX, the size can either be automatically
+  calculated from the surrounding text or set manually.
+- Changed 'resolution' to 'font size' (in px).- Changed 'resolution' to 'px'
+  (font height).
 
 --v0.7
 

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,13 @@
+--v0.7.1
+
+-- Changed 'resolution' to 'px' (font height).
+- Insert image in font size of surrounding text (if the 'autodpi'
+  configuration is set, otherwise in the configured font height).
+- When inserting complex LaTeX, the size can be automatically set
+  to the font size of the surrounding text or to a manually set
+  font size.
+- Beautified preferences dialog.
+
 --v0.7
 
 - Use latex/dvipng instead of latex/dvips/convert to generate the image file.

--- a/content/insert.js
+++ b/content/insert.js
@@ -1,6 +1,8 @@
 function on_ok() {
   var latex = document.getElementById("tblatex-expr").value;
-  window.arguments[0](latex);
+  var autodpi = document.getElementById("autodpi-checkbox").checked;
+  var font_px = document.getElementById("fontpx").value;
+  window.arguments[0](latex, autodpi, font_px);
 }
 
 function on_cancel() {
@@ -8,13 +10,49 @@ function on_cancel() {
 }
 
 window.addEventListener("load", function (event) {
-  document.getElementById("tblatex-expr").value = window.arguments[1];
+  var template = window.arguments[1];
+  var selection = window.arguments[2];
+  populate(template, selection);
+  var autodpi = prefs.getBoolPref("autodpi");
+  document.getElementById("autodpi-checkbox").checked = autodpi;
+  update_ui(autodpi);
+  var font_px = prefs.getIntPref("font_px");
+  document.getElementById("fontpx").value = font_px;
 }, false);
+
+function on_reset() {
+  var template = prefs.getCharPref("template");
+  populate(template, null);
+}
+
+function on_autodpi() {
+  var autodpi = document.getElementById("autodpi-checkbox").checked;
+  update_ui(autodpi);
+}
 
 var prefs = Components.classes["@mozilla.org/preferences-service;1"]
   .getService(Components.interfaces.nsIPrefService)
   .getBranch("tblatex.");
 
-function on_reset() {
-  document.getElementById("tblatex-expr").value = prefs.getCharPref("template");
+function populate(template, selection) {
+  var marker = "__REPLACE_ME__";
+  var start = template.indexOf(marker);
+  if (start > -1 && selection) {
+    // Replace marker with selection
+    template = template.substring(0, start) + selection + template.substring(start+marker.length)
+    marker = selection;
+  }
+
+  var textarea = document.getElementById("tblatex-expr");
+  textarea.value = template;
+  textarea.focus();
+  if (start > -1)
+    // Select marker or selection
+    textarea.setSelectionRange(start, start+marker.length);
+}
+
+function update_ui(autodpi) {
+  document.getElementById("fontpx-label").disabled = autodpi;
+  document.getElementById("fontpx").disabled = autodpi;
+  document.getElementById("fontpx-unit").disabled = autodpi;
 }

--- a/content/insert.xul
+++ b/content/insert.xul
@@ -15,11 +15,20 @@
     <dialogheader title="Latex It!" description="Insert a complex LaTeX expression"/>
     <groupbox>
       <description>Edit the default document below and the visible parts will be
-      inserted in your email</description>
+      inserted in your message:</description>
       <html:textarea id="tblatex-expr" multiline="true" rows="24" />
+    <hbox align="baseline">
+      <checkbox id="autodpi-checkbox" oncommand="on_autodpi();"
+        label="Adapt image resolution automatically to font size" />
+      <spacer flex="1" />
+      <label control="fontpx" id="fontpx-label" value="Font size:" />
+      <textbox id="fontpx"
+        type="number" min="1" decimalplaces="0" increment="1" size="2" />
+      <label control="fontpx" id="fontpx-unit" value="px" />
+    </hbox>
+  </groupbox>
       <hbox>
         <button label="Load default template" oncommand="on_reset();" />
         <spacer flex="1" />
       </hbox>
-   </groupbox>
 </dialog>

--- a/content/options.js
+++ b/content/options.js
@@ -39,3 +39,11 @@ function open_autodetect() {
   window.openDialog('chrome://tblatex/content/firstrun.html', '',
             'all,chrome,dialog=no,status,toolbar,width=640,height=480', add_links);
 }
+
+window.addEventListener("load", function (event) {
+  on_log();
+}, false);
+
+function on_log() {
+  document.getElementById("debug_checkbox").disabled = !document.getElementById("log_checkbox").checked;
+}

--- a/content/options.xul
+++ b/content/options.xul
@@ -10,47 +10,56 @@
 >
   <script type="application/javascript" src="chrome://tblatex/content/options.js" />
  
-  <vbox>
-    <hbox>
-      <label control="latex_textbox" value="Path to latex executable" />
+  <groupbox>
+    <label value="Executables:" style="header; font-weight: bold;" />
+    <hbox align="baseline">
+      <label control="latex_textbox" value="Path to latex executable:" />
       <textbox preference="tblatex.latex_path" id="latex_textbox" />
       <button label="Browse..." oncommand="pick_file(document.getElementsByTagName('textbox')[0], 'latex');" />
     </hbox>
-    <hbox>
-      <label control="dvipng_textbox" value="Path to dvipng executable" />
+    <hbox align="baseline">
+      <label control="dvipng_textbox" value="Path to dvipng executable:" />
       <textbox preference="tblatex.dvipng_path" id="dvipng_textbox" />
       <button label="Browse..." oncommand="pick_file(document.getElementsByTagName('textbox')[1], 'dvipng');" />
     </hbox>
-    <hbox>
-      <label control="dpi_textbox" value="Resolution (dpi)" />
-      <textbox preference="tblatex.dpi" id="dpi_textbox" />
-      <spacer />
-    </hbox>
-    <hbox>
-      <label control="log_checkbox" value="Generate a log report" />
-      <checkbox preference="tblatex.log" id="log_checkbox" />
-      <spacer />
-    </hbox>
-    <hbox>
-      <label control="debug_checkbox" value="Generate debug info" />
-      <checkbox preference="tblatex.debug" id="debug_checkbox" />
-      <spacer />
-    </hbox>
-    <label style="text-decoration: underline; color: navy; margin-top: 2em;
-      cursor: pointer" value="Open the autodetection dialog"
+    <label style="text-decoration: underline; color: navy; cursor: pointer" value="Open the autodetection dialog"
       onclick="open_autodetect();" />
-  </vbox>
-  
-  <vbox>
+  </groupbox>
+  <separator />
+  <groupbox>
+    <label value="Configurations:" style="header; font-weight: bold;" />
     <hbox>
-      <label control="template_textbox" value="Template to use to generate LaTeX parts "/>
+      <checkbox preference="tblatex.autodpi" id="autodpi_checkbox"
+        label="Adapt image resolution automatically to font size" />
+    </hbox>
+    <hbox align="baseline">
+      <label control="fontpx_textbox" value="Font size of image, if not automatically set:" />
+      <textbox preference="tblatex.font_px" id="fontpx_textbox"
+        type="number" min="1" decimalplaces="0" increment="1" size="2" />
+      <label control="fontpx_textbox" value="px" />
+    </hbox>
+    <hbox>
+      <checkbox preference="tblatex.log" id="log_checkbox"
+        label="Generate a log report" />
+    </hbox>
+    <hbox>
+      <checkbox preference="tblatex.debug" id="debug_checkbox"
+        label="debug_checkbox" value="Generate debug info" />
+    </hbox>
+  </groupbox>
+  <separator />
+  <groupbox>
+    <label value="Template:" style="header; font-weight: bold;" />
+    <hbox>
+      <label control="template_textbox" value="Template to use to generate LaTeX parts."/>
+      <spacer flex="1" />
       <label style="text-decoration: underline; color: navy; cursor: pointer" value="Help ?"
         onclick="window.openDialog('chrome://tblatex/content/help.html', '',
           'all,chrome,dialog=no,status,toolbar,width=640,height=480');" />
     </hbox>
     <html:textarea preference="tblatex.template" id="template_textbox" multiline="true"
       rows="12" />
-  </vbox>
+  </groupbox>
 
   <script
      src="chrome://global/content/preferencesBindings.js"

--- a/content/options.xul
+++ b/content/options.xul
@@ -39,7 +39,7 @@
       <label control="fontpx_textbox" value="px" />
     </hbox>
     <hbox>
-      <checkbox preference="tblatex.log" id="log_checkbox"
+      <checkbox preference="tblatex.log" id="log_checkbox" oncommand="on_log();"
         label="Generate a log report" />
     </hbox>
     <hbox>

--- a/content/options.xul
+++ b/content/options.xul
@@ -44,7 +44,7 @@
     </hbox>
     <hbox>
       <checkbox preference="tblatex.debug" id="debug_checkbox"
-        label="debug_checkbox" value="Generate debug info" />
+        label="Generate debug info" />
     </hbox>
   </groupbox>
   <separator />

--- a/content/preferences.js
+++ b/content/preferences.js
@@ -1,7 +1,8 @@
 Preferences.addAll([
   { id: "tblatex.latex_path", type: "string" },
   { id: "tblatex.dvipng_path", type: "string" },
-  { id: "tblatex.dpi", type: "int" },
+  { id: "tblatex.autodpi", type: "bool" },
+  { id: "tblatex.font_px", type: "int" },
   { id: "tblatex.log", type: "bool" },
   { id: "tblatex.debug", type: "bool" },
   { id: "tblatex.template", type: "string" },

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -1,6 +1,7 @@
 pref("tblatex.latex_path", "");
 pref("tblatex.dvipng_path", "");
-pref("tblatex.dpi", 150);
+pref("tblatex.autodpi", true);
+pref("tblatex.font_px", 16);
 pref("tblatex.log", true);
 pref("tblatex.debug", false);
 pref("tblatex.template", "\\documentclass{article}\n\\usepackage[utf8x]{inputenc}\n\\pagestyle{empty}\n\\begin{document}\n__REPLACEME__ %this is where your LaTeX expression goes\n\\end{document}\n");

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
   "author": "Jonathan Protzenko",
   "name": "LaTeX It!",
   "description": "Automatically change $\\LaTeX$ into images in your HTML mails.",
-  "version": "0.6.8",
+  "version": "0.7.1",
   "homepage_url": "https://github.com/protz/LatexIt/wiki",
   "legacy": true
 }


### PR DESCRIPTION
- Added autoscaling of images to font size (can be switched off in the preferences, where a size can be manually set).
- When inserting a complex LaTeX, the size can either be automatically calculated from the surrounding text or set manually.
- Changed 'resolution' to 'font size' (in px).