### PR TITLE
All-in-one PR including #46 #47 #50 #51 #52

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,26 @@
+--v0.7.1
+
+- Fixed the insertion of complex LaTeX (Bug #43).
+- Select the insertion marker when opening the insert complex LaTeX dialog.
+- Cleaned up the options dialog.
+- Replaced place holder __REPLACEME__ with __REPLACE_ME__, which IMHO is easier
+  to the eye.
+- Added alignment of inserted pictures to the text baseline (Bug #36).
+- Added improvements of LaTeXIt! button:
+  - Button is disabled for plain text composer windows (Bug #48).
+  - Middle click calls 'undo' (Bug #2).
+  - Shift+middle click calls 'undo_all'.
+- Added context menu to composer window (Bug #49).
+- Added LaTeXIt! to the Add-ons menu to access the preferences (Bug #42).
+- Removed the configuration item from toolbar and context menues, because they
+  are not needed anymore.
+- Delete all cached images when the composer window is closed (Bug #44).
+- Added autoscaling of images to font size (can be switched off in the
+  preferences, where a size can be manually set).
+- When inserting a complex LaTeX, the size can either be automatically
+  calculated from the surrounding text or set manually.
+- Use 'font size' (in px) instead of 'resolution'.
+
 --v0.7
 
 - Use latex/dvipng instead of latex/dvips/convert to generate the image file.

--- a/content/help.html
+++ b/content/help.html
@@ -17,9 +17,10 @@
     <pre>
 \documentclass{article}
 \usepackage[utf8x]{inputenc}
+\usepackage[active,displaymath,textmath]{preview}
 \pagestyle{empty}
 \begin{document}
-__REPLACEME__ %this is where your LaTeX expression goes
+__REPLACE_ME__ %this is where your LaTeX expression goes
 \end{document}
     </pre>
    <p>
@@ -29,7 +30,7 @@ __REPLACEME__ %this is where your LaTeX expression goes
     extra output such as page numbers, which is why cropping works.
     </p>
     <p>
-    The <tt>__REPLACEME__</tt> word will be replaced with the LaTeX expression
+    The <tt>__REPLACE_ME__</tt> word will be replaced with the LaTeX expression
     you specified. Therefore, it is important you put it in the right place.
     </p>
     <p>
@@ -46,13 +47,14 @@ __REPLACEME__ %this is where your LaTeX expression goes
     <pre>
 \documentclass{article}
 \usepackage[utf8x]{inputenc}
+\usepackage[active,displaymath,textmath]{preview}
 \usepackage{amsmath,amssymb,amsopn}
 \usepackage{mathrsfs}
 \usepackage{palatino}
 \usepackage{mathpazo}
 \pagestyle{empty}
 \begin{document}
-__REPLACEME__ %this is where your LaTeX expression goes
+__REPLACE_ME__ %this is where your LaTeX expression goes
 \end{document}
     </pre>
  

--- a/content/insert.js
+++ b/content/insert.js
@@ -1,20 +1,54 @@
 function on_ok() {
   var latex = document.getElementById("tblatex-expr").value;
-  window.arguments[0](latex);
-}
-
-function on_cancel() {
-  window.close();
+  var autodpi = document.getElementById("autodpi-checkbox").checked;
+  var font_px = document.getElementById("fontpx").value;
+  window.arguments[0](latex, autodpi, font_px);
 }
 
 window.addEventListener("load", function (event) {
-  document.getElementById("tblatex-expr").value = window.arguments[1];
+  var template = window.arguments[1];
+  var selection = window.arguments[2];
+  populate(template, selection);
+  var autodpi = prefs.getBoolPref("autodpi");
+  document.getElementById("autodpi-checkbox").checked = autodpi;
+  update_ui(autodpi);
+  var font_px = prefs.getIntPref("font_px");
+  document.getElementById("fontpx").value = font_px;
 }, false);
+
+function on_reset() {
+  var template = prefs.getCharPref("template");
+  populate(template, null);
+}
+
+function on_autodpi() {
+  var autodpi = document.getElementById("autodpi-checkbox").checked;
+  update_ui(autodpi);
+}
 
 var prefs = Components.classes["@mozilla.org/preferences-service;1"]
   .getService(Components.interfaces.nsIPrefService)
   .getBranch("tblatex.");
 
-function on_reset() {
-  document.getElementById("tblatex-expr").value = prefs.getCharPref("template");
+function populate(template, selection) {
+  var marker = "__REPLACE_ME__";
+  var start = template.indexOf(marker);
+  if (start > -1 && selection) {
+    // Replace marker with selection
+    template = template.substring(0, start) + selection + template.substring(start+marker.length)
+    marker = selection;
+  }
+
+  var textarea = document.getElementById("tblatex-expr");
+  textarea.value = template;
+  textarea.focus();
+  if (start > -1)
+    // Select marker or selection
+    textarea.setSelectionRange(start, start+marker.length);
+}
+
+function update_ui(autodpi) {
+  document.getElementById("fontpx-label").disabled = autodpi;
+  document.getElementById("fontpx").disabled = autodpi;
+  document.getElementById("fontpx-unit").disabled = autodpi;
 }

--- a/content/insert.xul
+++ b/content/insert.xul
@@ -5,21 +5,28 @@
   title="Insert a LaTeX expression"
   xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
   xmlns:html="http://www.w3.org/1999/xhtml"
-  buttons="accept,cancel"
-  buttonlabelcancel="Cancel"
-  buttonlabelaccept="Ok"
-  ondialogaccept="return on_ok();"
-  ondialogcancel="return on_cancel();">
+  buttons="cancel"
+  buttonlabelcancel="Close">
   <script type="application/javascript" src="chrome://tblatex/content/insert.js" />
     
     <dialogheader title="Latex It!" description="Insert a complex LaTeX expression"/>
     <groupbox>
       <description>Edit the default document below and the visible parts will be
-      inserted in your email</description>
+      inserted in your message:</description>
       <html:textarea id="tblatex-expr" multiline="true" rows="24" />
+    <hbox align="baseline">
+      <checkbox id="autodpi-checkbox" oncommand="on_autodpi();"
+        label="Adapt image resolution automatically to font size" />
+      <spacer flex="1" />
+      <label control="fontpx" id="fontpx-label" value="Font size:" />
+      <textbox id="fontpx"
+        type="number" min="1" decimalplaces="0" increment="1" size="2" />
+      <label control="fontpx" id="fontpx-unit" value="px" />
+    </hbox>
+  </groupbox>
       <hbox>
         <button label="Load default template" oncommand="on_reset();" />
         <spacer flex="1" />
+    <button label="Insert at cursor position" oncommand="on_ok();" />
       </hbox>
-   </groupbox>
 </dialog>

--- a/content/main.js
+++ b/content/main.js
@@ -435,7 +435,7 @@ var tblatex = {
     if (event.button == 2) return;
     var editor_elt = document.getElementById("content-frame");
     if (editor_elt.editortype != "htmlmail") {
-      alert("Cannot Latexify plain text emails. Start again by and open the message composer window while holding the 'Shift' key.");
+      alert("Cannot Latexify plain text emails. Start again by opening the message composer window while holding the 'Shift' key.");
       return;
     }
 
@@ -601,6 +601,7 @@ var tblatex = {
         try {
           f.initWithPath(g_image_cache[key]);
           f.remove(false);
+          delete g_image_cache[key];
         } catch (e) { }
       }
     }, false);

--- a/content/main.js
+++ b/content/main.js
@@ -1,5 +1,6 @@
 var tblatex = {
   on_latexit: null,
+  on_middleclick: null,
   on_undo: null,
   on_undo_all: null,
   on_insert_complex: null,
@@ -81,13 +82,14 @@ var tblatex = {
    * cache which I haven't found a way to invalidate yet. */
   var g_suffix = 1;
 
-  /* Returns [st, src, log] where :
+  /* Returns [st, src, depth, log] where :
    * - st is 0 if everything went ok, 1 if some error was found but the image
    *   was nonetheless generated, 2 if there was a fatal error
    * - src is the local path of the image if generated
+   * - depth is the number of pixels from the bottom of the image to the baseline of the image
    * - log is the log messages generated during the run
    * */
-  function run_latex(latex_expr, silent) {
+  function run_latex(latex_expr, font_px) {
     var log = "";
     var st = 0;
     var temp_file;
@@ -100,10 +102,10 @@ var tblatex = {
         log += ("\n*** Generating LaTeX expression:\n"+latex_expr+"\n");
       }
 
-      if (g_image_cache[latex_expr]) {
+      if (g_image_cache[latex_expr+font_px]) {
         if (debug)
-          log += "Found a cached image file "+g_image_cache[latex_expr]+", returning\n";
-        return [0, g_image_cache[latex_expr], log+"Image was already generated\n"];
+          log += "Found a cached image file "+g_image_cache[latex_expr+font_px]+", returning\n";
+        return [0, g_image_cache[latex_expr+font_px], 0, log+"Image was already generated\n"];
       }
 
       var init_file = function(path) {
@@ -128,12 +130,19 @@ var tblatex = {
       var latex_bin = init_file(prefs.getCharPref("latex_path"));
       if (!latex_bin.exists()) {
         log += "Wrong path for latex bin. Please set the right path in the options dialog first.\n";
-        return [2, "", log];
+        return [2, "", 0, log];
       }
       var dvipng_bin = init_file(prefs.getCharPref("dvipng_path"));
       if (!dvipng_bin.exists()) {
         log += "Wrong path for dvipng bin. Please set the right path in the options dialog first.\n";
-        return [2, "", log];
+        return [2, "", 0, log];
+      }
+      if (isWindows) {
+        var shell_bin = init_file(env.get("COMSPEC"));
+        var shell_option = "/C";
+      } else {
+        var shell_bin = init_file("/bin/sh");
+        var shell_option = "-c";
       }
 
       var temp_dir = Components.classes["@mozilla.org/file/directory_service;1"].
@@ -190,24 +199,63 @@ var tblatex = {
       dvi_file.append(temp_file_noext+".dvi");
       if (!dvi_file.exists()) {
         log += "LaTeX did not output a .dvi file, something definitely went wrong. Aborting.\n";
-        return [2, "", log];
+        return [2, "", 0, log];
       }
 
       var png_file = init_file(temp_dir);
       png_file.append(temp_file_noext+".png");
+      var depth_file = init_file(temp_dir);
+      depth_file.append(temp_file_noext+"-depth.txt");
 
-      var dvipng_process = init_process(dvipng_bin);
-      var dpi = prefs.getIntPref("dpi");
-      var dvipng_args = ["-T", "tight", "-D", dpi, "-o", png_file.path, dvi_file.path];
-      dvipng_process.run(true, dvipng_args, dvipng_args.length);
+      // Output resolution to fit font size (see 'man dvipng', option -D) for LaTeX default font height 10 pt
+      //
+      //   -D num
+      //       Set the output resolution, both horizontal and vertical, to num dpi
+      //       (dots per inch).
+      //
+      //       One may want to adjust this to fit a certain text font size (e.g.,
+      //       on a web page), and for a text font height of font_px pixels (in
+      //       Mozilla) the correct formula is
+      //
+      //               <dpi> = <font_px> * 72.27 / 10 [px * TeXpt/in / TeXpt]
+      //
+      //       The last division by ten is due to the standard font height 10pt in
+      //       your document, if you use 12pt, divide by 12. Unfortunately, some
+      //       proprietary browsers have font height in pt (points), not pixels.
+      //       You have to rescale that to pixels, using the screen resolution
+      //       (default is usually 96 dpi) which means the formula is
+      //
+      //               <font_px> = <font_pt> * 96 / 72 [pt * px/in / (pt/in)]
+      //
+      //      On some high-res screens, the value is instead 120 dpi. Good luck!
+      //
+      // Looks like Thunderbird is one of the "proprietary browsers", at least if I assumed that
+      // the font size returned is in points (and not pixels) I get the right size with a screen
+      // resolution of 96.
+      if (prefs.getBoolPref("autodpi") && font_px) {
+        var font_size = parseFloat(font_px);
+        if (debug)
+          log += "*** Surrounding text has font size of "+font_px+"\n";
+      } else {
+        var font_size = prefs.getIntPref("font_px");
+        if (debug)
+          log += "*** Using font size "+font_size+"px set in preferences\n";
+      }
+      var dpi = font_size * 72.27 / 10;
+      if (debug)
+        log += "*** Calculated resolution is "+dpi+" dpi\n";
+
+      var shell_process = init_process(shell_bin);
+      var dvipng_args = [dvipng_bin.path, "--depth", "-T", "tight", "-D", dpi, "-o", png_file.path, dvi_file.path, ">", depth_file.path];
+      shell_process.run(true, [shell_option, dvipng_args.join(" ")], 2);
       dvi_file.remove(false);
       if (debug)
-        log += "I ran "+dvipng_bin.path+" "+dvipng_args.join(" ")+"\n";
-      if (dvipng_process.exitValue) {
-        log += "dvipng failed with error code "+dvipng_process.exitValue+". Aborting.\n";
-        return [2, "", log];
+        log += "I ran "+shell_bin.path+" -c '"+dvipng_args.join(" ")+"'\n";
+      if (shell_process.exitValue) {
+        log += "dvipng failed with error code "+shell_process.exitValue+". Aborting.\n";
+        return [2, "", 0, log];
       }
-      g_image_cache[latex_expr] = png_file.path;
+      g_image_cache[latex_expr+font_px] = png_file.path;
 
       if (debug) {
         log += ("*** Status is "+st+"\n");
@@ -222,17 +270,52 @@ var tblatex = {
         }, 500);
       }
 
+      // Read the depth (distance between base of image and baseline) from the depth file
+      if (!depth_file.exists()) {
+        log += "dvipng did not put out a depth file. Continuing without alignment.\n";
+        return [st, png_file.path, 0, log];
+      }
+
+      // https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Code_snippets/File_I_O#Line_by_line
+      // Open an input stream from file
+      var istream = Components.classes["@mozilla.org/network/file-input-stream;1"].
+                    createInstance(Components.interfaces.nsIFileInputStream);
+      istream.init(depth_file, 0x01, 0444, 0);
+      istream.QueryInterface(Components.interfaces.nsILineInputStream);
+
+      // Read line by line and look for the depth information, which is contained in a line such as
+      //    [1 depth=4]
+      var re = /^\[[0-9] +depth=([0-9]+)\] *$/;
+      var line = {}, hasmore;
+      var depth = 0;
+      do {
+        hasmore = istream.readLine(line);
+        var linematch = line.value.match(re);
+        if (linematch) {
+          // Matching line found, get depth information and exit loop
+          depth = linematch[1];
+          if (debug)
+            log += ("*** Depth is "+depth+"\n");
+          break;
+        }
+      } while(hasmore);
+
+      // Close input stream
+      istream.close();
+      
+      depth_file.remove(false);
+
       // Only delete the temporary file at this point, so that it's left on disk
       //  in case of error.
       temp_file.remove(false);
 
-      return [st, png_file.path, log];
+      return [st, png_file.path, depth, log];
     } catch (e) {
       dump(e+"\n");
       dump(e.stack+"\n");
       log += "Severe error. Missing package?\n";
       log += "We left the .tex file there: "+temp_file.path+", try to run latex on it by yourself...\n";
-      return [2, "", log];
+      return [2, "", 0, log];
     }
   }
 
@@ -303,8 +386,10 @@ var tblatex = {
       var elt = nodes[i];
       if (!silent)
         write_log("*** Found expression "+elt.nodeValue+"\n");
-      var latex_expr = replace(template, "__REPLACEME__", elt.nodeValue);
-      var [st, url, log] = run_latex(latex_expr, silent);
+      var latex_expr = replace(template, "__REPLACE_ME__", elt.nodeValue);
+      // Font size in pixels
+      var font_px = window.getComputedStyle(elt.parentElement, null).getPropertyValue('font-size');
+      var [st, url, depth, log] = run_latex(latex_expr, font_px);
       if (st || !silent)
         write_log(log);
       if (st == 0 || st == 1) {
@@ -323,7 +408,7 @@ var tblatex = {
           elt.parentNode.removeChild(elt);
 
           img.alt = elt.nodeValue;
-          img.style = "vertical-align: middle";
+          img.style = "vertical-align: -" + depth + "px";
           img.src = reader.result;
 
           push_undo_func(function () {
@@ -350,7 +435,7 @@ var tblatex = {
     if (event.button == 2) return;
     var editor_elt = document.getElementById("content-frame");
     if (editor_elt.editortype != "htmlmail") {
-      alert("Cannot Latexify plain text emails. Use Options > Format to switch to HTML Mail.");
+      alert("Cannot Latexify plain text emails. Start again by and open the message composer window while holding the 'Shift' key.");
       return;
     }
 
@@ -369,7 +454,26 @@ var tblatex = {
     editor.endTransaction();
   };
 
+  tblatex.on_middleclick = function(event) {
+    // Return on all but the middle button
+    if (event.button != 1) return;
+
+    if (event.shiftKey) {
+      // Undo all
+      undo_all();
+    } else {
+      // Undo
+      undo();
+    }
+    event.stopPropagation();
+  };
+
   tblatex.on_undo = function (event) {
+    undo();
+    event.stopPropagation();
+  };
+
+  function undo() {
     var editor = GetCurrentEditor();
     editor.beginTransaction();
     try {
@@ -380,10 +484,14 @@ var tblatex = {
       dumpCallStack(e);
     }
     editor.endTransaction();
+  }
+
+  tblatex.on_undo_all = function (event) {
+    undo_all();
     event.stopPropagation();
   };
 
-  tblatex.on_undo_all = function (event) {
+  function undo_all() {
     var editor = GetCurrentEditor();
     editor.beginTransaction();
     try {
@@ -394,23 +502,32 @@ var tblatex = {
       dumpCallStack(e);
     }
     editor.endTransaction();
-    event.stopPropagation();
   };
 
   var g_complex_input = null;
 
   tblatex.on_insert_complex = function (event) {
     var editor = GetCurrentEditor();
-    var f = function (latex_expr) {
+    var f = function (latex_expr, autodpi, font_size) {
+      var debug = prefs.getBoolPref("debug");
       g_complex_input = latex_expr;
       editor.beginTransaction();
       try {
         close_log();
         var write_log = open_log();
-        var [st, url, log] = run_latex(latex_expr);
+        if (autodpi) {
+          // Font size at cursor position
+          var elt = editor.selection.anchorNode.parentElement;
+          var font_px = window.getComputedStyle(elt).getPropertyValue('font-size');
+        } else {
+          var font_px = font_size+"px";
+        }
+        var [st, url, depth, log] = run_latex(latex_expr, font_px);
         log = log || "Everything went OK.\n";
         write_log(log);
         if (st == 0 || st == 1) {
+          if (debug)
+            write_log("--> Inserting at cursor position... ");
           var img = editor.createElementWithDefaults("img");
           var reader = new FileReader();
           var xhr = new XMLHttpRequest();
@@ -424,17 +541,23 @@ var tblatex = {
 
             img.alt = latex_expr;
             img.title = latex_expr;
-            img.style = "vertical-align: middle";
+            img.style = "vertical-align: -" + depth + "px";
             img.src = reader.result;
 
             push_undo_func(function () {
               img.parentNode.removeChild(img);
             });
+            if (debug)
+              write_log("done\n");
           }, false);
 
           xhr.open('GET',"file://"+url);
           xhr.responseType = 'blob';
+          xhr.overrideMimeType("image/png");
           xhr.send();
+        } else {
+          if (debug)
+            write_log("--> Failed, not inserting\n");
         }
       } catch (e) {
         Components.utils.reportError("TBLatex Error (while inserting) "+e);
@@ -443,19 +566,42 @@ var tblatex = {
       editor.endTransaction();
     };
     var template = g_complex_input || prefs.getCharPref("template");
-    window.openDialog("chrome://tblatex/content/insert.xul", "", "chrome", f, template);
+    var selection = editor.selection.toString();
+    window.openDialog("chrome://tblatex/content/insert.xul", "", "chrome, resizable=yes", f, template, selection);
     event.stopPropagation();
   };
 
-  tblatex.on_open_options = function (event) {
-    window.openDialog("chrome://tblatex/content/options.xul", "", "");
-    event.stopPropagation();
-  };
-
-  /* Is this even remotey useful ? */
+  /* Yes, because we can disable the toolbar button and menu items for plain text messages! */
   window.addEventListener("load",
     function () {
       var tb = document.getElementById("composeToolbar2");
       tb.setAttribute("defaultset", tb.getAttribute("defaultset")+",tblatex-button-1");
+
+      // Disable the button and menu for non-html composer windows
+      var editor_elt = document.getElementById("content-frame");
+      if (editor_elt.editortype != "htmlmail") {
+      var btn = document.getElementById("tblatex-button-1");
+      if (btn) {
+          btn.tooltipText = "Start a message in HTML format (by holding the 'Shift' key) to be able to turn every $...$ into a LaTeX image"
+          btn.disabled = true;
+        }
+        for (var id of ["tblatex-context", "tblatex-context-menu"]) {
+            var menu = document.getElementById(id);
+            if (menu)
+                menu.disabled = true;
+        }
+      }
+    }, false);
+
+  window.addEventListener("unload",
+    // Remove all cached images on closing the composer window
+    function() {
+      for (var key in g_image_cache) {
+        var f = Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsIFile);
+        try {
+          f.initWithPath(g_image_cache[key]);
+          f.remove(false);
+        } catch (e) { }
+      }
     }, false);
 })()

--- a/content/options.js
+++ b/content/options.js
@@ -39,3 +39,11 @@ function open_autodetect() {
   window.openDialog('chrome://tblatex/content/firstrun.html', '',
             'all,chrome,dialog=no,status,toolbar,width=640,height=480', add_links);
 }
+
+window.addEventListener("load", function (event) {
+  on_log();
+}, false);
+
+function on_log() {
+  document.getElementById("debug_checkbox").disabled = !document.getElementById("log_checkbox").checked;
+}

--- a/content/options.xul
+++ b/content/options.xul
@@ -10,47 +10,57 @@
 >
   <script type="application/javascript" src="chrome://tblatex/content/options.js" />
  
-  <vbox>
-    <hbox>
-      <label control="latex_textbox" value="Path to latex executable" />
+  <groupbox>
+    <label value="Executables:" style="header; font-weight: bold;" />
+    <hbox align="baseline">
+      <label control="latex_textbox" value="Path to latex executable:" />
       <textbox preference="tblatex.latex_path" id="latex_textbox" />
       <button label="Browse..." oncommand="pick_file(document.getElementsByTagName('textbox')[0], 'latex');" />
     </hbox>
-    <hbox>
-      <label control="dvipng_textbox" value="Path to dvipng executable" />
+    <hbox align="baseline">
+      <label control="dvipng_textbox" value="Path to dvipng executable:" />
       <textbox preference="tblatex.dvipng_path" id="dvipng_textbox" />
       <button label="Browse..." oncommand="pick_file(document.getElementsByTagName('textbox')[1], 'dvipng');" />
     </hbox>
-    <hbox>
-      <label control="dpi_textbox" value="Resolution (dpi)" />
-      <textbox preference="tblatex.dpi" id="dpi_textbox" />
-      <spacer />
-    </hbox>
-    <hbox>
-      <label control="log_checkbox" value="Generate a log report" />
-      <checkbox preference="tblatex.log" id="log_checkbox" />
-      <spacer />
-    </hbox>
-    <hbox>
-      <label control="debug_checkbox" value="Generate debug info" />
-      <checkbox preference="tblatex.debug" id="debug_checkbox" />
-      <spacer />
-    </hbox>
-    <label style="text-decoration: underline; color: navy; margin-top: 2em;
-      cursor: pointer" value="Open the autodetection dialog"
+    <label style="text-decoration: underline; color: navy; cursor: pointer" value="Open the autodetection dialog"
       onclick="open_autodetect();" />
-  </vbox>
-  
-  <vbox>
+  </groupbox>
+  <separator />
+  <groupbox>
+    <label value="Configurations:" style="header; font-weight: bold;" />
     <hbox>
-      <label control="template_textbox" value="Template to use to generate LaTeX parts "/>
+      <checkbox preference="tblatex.autodpi" id="autodpi_checkbox"
+        label="Adapt image resolution automatically to font size" />
+    </hbox>
+    <hbox align="baseline">
+      <label control="fontpx_textbox" value="Font size of image, if not automatically set:" />
+      <textbox preference="tblatex.font_px" id="fontpx_textbox"
+        type="number" min="1" decimalplaces="0" increment="1" size="2" />
+      <label control="fontpx_textbox" value="px" />
+    </hbox>
+    <hbox>
+      <checkbox preference="tblatex.log" id="log_checkbox"
+        label="Generate a log report" />
+    </hbox>
+    <hbox>
+      <checkbox preference="tblatex.debug" id="debug_checkbox"
+        label="Generate debug info" />
+    </hbox>
+  </groupbox>
+  <separator />
+  <groupbox>
+    <label value="Template:" style="header; font-weight: bold;" />
+    <hbox>
+      <label control="template_textbox" value="Template to use to generate LaTeX parts."/>
+      <spacer flex="1" />
       <label style="text-decoration: underline; color: navy; cursor: pointer" value="Help ?"
         onclick="window.openDialog('chrome://tblatex/content/help.html', '',
           'all,chrome,dialog=no,status,toolbar,width=640,height=480');" />
     </hbox>
+    <description>Use __REPLACE_ME__ as a place marker, if you want to have it automatically highlighted.</description>
     <html:textarea preference="tblatex.template" id="template_textbox" multiline="true"
       rows="12" />
-  </vbox>
+  </groupbox>
 
   <script
      src="chrome://global/content/preferencesBindings.js"

--- a/content/options.xul
+++ b/content/options.xul
@@ -39,7 +39,7 @@
       <label control="fontpx_textbox" value="px" />
     </hbox>
     <hbox>
-      <checkbox preference="tblatex.log" id="log_checkbox"
+      <checkbox preference="tblatex.log" id="log_checkbox" oncommand="on_log();"
         label="Generate a log report" />
     </hbox>
     <hbox>

--- a/content/overlay.xul
+++ b/content/overlay.xul
@@ -9,13 +9,37 @@
       oncommand="tblatex.on_latexit(event, true);"
       />
   </keyset>
+  <popup id="msgComposeContext">
+    <menuseparator />
+    <menuitem id="tblatex-context"
+      label="LaTeX It!"
+      class="menuitem-iconic"
+      oncommand="tblatex.on_latexit(event, false);" />
+    <menu id="tblatex-context-menu"
+      label="More LaTeX It!">
+      <menupopup id="tblatex-context-popup">
+        <menuitem id="tblatex-context-undo"
+          label="Undo"
+          oncommand="tblatex.on_undo(event);" />
+        <menuitem id="tblatex-context-undo_all"
+          label="Undo All"
+          oncommand="tblatex.on_undo_all(event);" />
+        <menuseparator />
+        <menuitem id="tblatex-context-insert_complex"
+          label="Insert complex LaTeX"
+          oncommand="tblatex.on_insert_complex(event);" />
+      </menupopup>
+    </menu>
+    <menuseparator />
+  </popup>
   <toolbarpalette id="MsgComposeToolbarPalette">
     <toolbarbutton id="tblatex-button-1"
       class="toolbarbutton-1"
       label="Latex It!"
-      tooltiptext="Turn every $$ into a LaTeX image (Ctrl/Meta-Shift-L for silent run)"
+      tooltiptext="Turn every $...$ into a LaTeX image (Ctrl/Meta-Shift-L for silent run)"
       type="menu-button"
       oncommand="tblatex.on_latexit(event, false);"
+      onclick="tblatex.on_middleclick(event);"
       >
       <menupopup>
         <menuitem label="Undo" id="tblatex-button-undo"
@@ -30,11 +54,6 @@
         <menuitem label="Insert complex LaTeX" id="tblatex-button-insert_complex"
           oncommand="tblatex.on_insert_complex(event);"
           tooltiptext="Open a dialog to insert an arbitrary chunk of LaTeX"
-          />
-        <menuseparator />
-        <menuitem label="Options" id="tblatex-button-open_options"
-          oncommand="tblatex.on_open_options(event);"
-          tooltiptext="Open the options dialog"
           />
       </menupopup>
     </toolbarbutton>

--- a/content/preferences.js
+++ b/content/preferences.js
@@ -1,7 +1,8 @@
 Preferences.addAll([
   { id: "tblatex.latex_path", type: "string" },
   { id: "tblatex.dvipng_path", type: "string" },
-  { id: "tblatex.dpi", type: "int" },
+  { id: "tblatex.autodpi", type: "bool" },
+  { id: "tblatex.font_px", type: "int" },
   { id: "tblatex.log", type: "bool" },
   { id: "tblatex.debug", type: "bool" },
   { id: "tblatex.template", type: "string" },

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -1,8 +1,9 @@
 pref("tblatex.latex_path", "");
 pref("tblatex.dvipng_path", "");
-pref("tblatex.dpi", 150);
+pref("tblatex.autodpi", true);
+pref("tblatex.font_px", 16);
 pref("tblatex.log", true);
 pref("tblatex.debug", false);
-pref("tblatex.template", "\\documentclass{article}\n\\usepackage[utf8x]{inputenc}\n\\pagestyle{empty}\n\\begin{document}\n__REPLACEME__ %this is where your LaTeX expression goes\n\\end{document}\n");
+pref("tblatex.template", "\\documentclass{article}\n\\usepackage[utf8x]{inputenc}\n\\usepackage[active,displaymath,textmath]{preview}\n\\pagestyle{empty}\n\\begin{document}\n__REPLACE_ME__ %this is where your LaTeX expression goes\n\\end{document}\n");
 pref("tblatex.firstrun", 0);
 

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,13 @@
   "author": "Jonathan Protzenko",
   "name": "LaTeX It!",
   "description": "Automatically change $\\LaTeX$ into images in your HTML mails.",
-  "version": "0.6.8",
+  "version": "0.7.1",
   "homepage_url": "https://github.com/protz/LatexIt/wiki",
-  "legacy": true
+  "legacy": {
+    "type": "xul",
+    "options": {
+      "page": "chrome://tblatex/content/options.xul",
+      "open_in_tab": false
+    }
+  }
 }


### PR DESCRIPTION
Hi Jonathan @protz ,

What started as a tiny exercise to sort out the insertion of complex LaTeX turned out to become a bit more elaborated. My first idea was to keep them all separated to help in cherry picking the PRs you like, but I am not sure if I managed to keep them really separate. I might have missed one or two diffs (but I do not hope so). So here comes the all-in-one PR including #46 #47 #50 #51 #52. Feel free to use this one or any of the others. And thanks for starting this wonderful add-on!

Here is an overview of all the changes:
- Increased version to 0.7.1.
- Fixed the insertion of complex LaTeX (Bug #43).
- Select the insertion marker when opening the insert complex LaTeX dialog.
- Cleaned up the options dialog.
- Replaced place holder `__REPLACEME__` with `__REPLACE_ME__`, which IMHO is easier
  to the eye.
- Added alignment of inserted pictures to the text baseline (Bug #36).
- Added improvements of LaTeXIt! button:
  - Button is disabled for plain text composer windows (Bug #48).
  - Middle click calls 'undo' (Bug #2).
  - Shift+middle click calls 'undo_all'.
- Added context menu to composer window (Bug #49).
- Added LaTeXIt! to the Add-ons menu to access the preferences (Bug #42).
- Removed the configuration item from toolbar and context menus, because they
  are not needed anymore.
- Delete all cached images when the composer window is closed (Bug #44).
- Added autoscaling of images to font size (can be switched off in the
  preferences, where a size can be manually set).
- When inserting a complex LaTeX, the size can either be automatically
  calculated from the surrounding text or set manually.
- Use 'font size' (in px) instead of 'resolution'.