### PR TITLE
Check before sending, if a LatexIt! report exists in the message.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+--v0.7.1
+
+- Check before sending, if a LatexIt! report exists in the message.
+
 --v0.7
 
 - Use latex/dvipng instead of latex/dvips/convert to generate the image file.

--- a/content/main.js
+++ b/content/main.js
@@ -452,6 +452,48 @@ var tblatex = {
     event.stopPropagation();
   };
 
+  function check_log_report () {
+    // code from close_log();
+    var editor = document.getElementById("content-frame");
+    var edocument = editor.contentDocument;
+    var div = edocument.getElementById("tblatex-log");
+    if (div) {
+      var retVals = {action: -1};
+      window.openDialog("chrome://tblatex/content/sendalert.xul", "", "chrome,modal,dialog,centerscreen", retVals);
+      switch (retVals.action) {
+        case 0:
+          div.parentNode.removeChild(div);
+          return true;
+        case 1:
+          return true;
+        default:
+          return false;
+      }
+    } else {
+      return true;
+    }
+  }
+
+  // Override original send functions (this follows the approach from the "Check and Send" add-on
+  var tblatex_SendMessage_orig = SendMessage;
+  SendMessage = function() {
+    if (check_log_report())
+      tblatex_SendMessage_orig.apply(this, arguments);
+  }
+
+  // Ctrl-Enter
+  var tblatex_SendMessageWithCheck_orig = SendMessageWithCheck;
+  SendMessage = function() {
+    if (check_log_report())
+      tblatex_SendMessageWithCheck_orig.apply(this, arguments);
+  }
+
+  var tblatex_SendMessageLater_orig = SendMessageLater;
+  SendMessage = function() {
+    if (check_log_report())
+      tblatex_SendMessageLater_orig.apply(this, arguments);
+  }
+
   /* Is this even remotey useful ? */
   window.addEventListener("load",
     function () {

--- a/content/main.js
+++ b/content/main.js
@@ -483,13 +483,13 @@ var tblatex = {
 
   // Ctrl-Enter
   var tblatex_SendMessageWithCheck_orig = SendMessageWithCheck;
-  SendMessage = function() {
+  SendMessageWithCheck = function() {
     if (check_log_report())
       tblatex_SendMessageWithCheck_orig.apply(this, arguments);
   }
 
   var tblatex_SendMessageLater_orig = SendMessageLater;
-  SendMessage = function() {
+  SendMessageLater = function() {
     if (check_log_report())
       tblatex_SendMessageLater_orig.apply(this, arguments);
   }

--- a/content/sendalert.js
+++ b/content/sendalert.js
@@ -1,0 +1,20 @@
+function on_send() {
+console.log("LATEX OK *********");
+  var retVals = window.arguments[0];
+  retVals.action = 1;
+  close();
+}
+
+function on_cancel() {
+console.log("LATEX Cancel *********");
+  var retVals = window.arguments[0]
+  retVals.action = -1;
+  close();
+}
+
+function on_removeandsend(event) {
+console.log("LATEX Remove and send *********");
+  var retVals = window.arguments[0]
+  retVals.action = 0;
+  close();
+}

--- a/content/sendalert.xul
+++ b/content/sendalert.xul
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href="chrome://global/skin/global.css" type="text/css"?>
+
+<dialog id="tblatex-dialog-sendalert"
+  title="Send with LatexIt! report"
+  xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+  xmlns:html="http://www.w3.org/1999/xhtml"
+  buttons=",">
+  <script type="application/javascript" src="chrome://tblatex/content/sendalert.js" />
+
+  <description>There exists a LatexIt! report in your message!</description>
+  <separator />
+  <hbox>
+    <button label="Cancel" oncommand="on_cancel();" />
+    <spacer flex="1" />
+    <button label="Remove report and send" oncommand="on_removeandsend();" />
+    <spacer flex="1" />
+    <button label="Send" oncommand="on_send();" />
+  </hbox>
+</dialog>

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
   "author": "Jonathan Protzenko",
   "name": "LaTeX It!",
   "description": "Automatically change $\\LaTeX$ into images in your HTML mails.",
-  "version": "0.6.8",
+  "version": "0.7.1",
   "homepage_url": "https://github.com/protz/LatexIt/wiki",
   "legacy": true
 }


### PR DESCRIPTION
It happened to me a couple of times that I send a email with the LatexIt! report still showing. This PR checks for such a report before sending, If there is one, it pops up a message box asking the user if it should removed before sending the message.

Please note, this is not included in the all-in-one pull request #53 !