### PR TITLE
Use "\usepackage[utf8x]{inputenc}" instead of "\usepackage[utf8]{inputenc}"

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -23,6 +23,9 @@
 - Check before sending, if a LatexIt! report exists in the message.
 - Display an error message, if the place holder "__REPLACE_ME__" cannot be found in the template. (https://github.com/protz/LatexIt/pull/53#discussion_r450431520)
 - Added "!!!" in front of error messages.
+- Use "\usepackage[utf8x]{inputenc}" instead of "\usepackage[utf8]{inputenc}",
+  which should remove the (Debian) dependency of package texlive-latex-extra
+  (Bug #8).
 
 --v0.7
 

--- a/content/help.html
+++ b/content/help.html
@@ -16,7 +16,7 @@
     </p>
     <pre>
 \documentclass{article}
-\usepackage[utf8x]{inputenc}
+\usepackage[utf8]{inputenc}
 \usepackage[active,displaymath,textmath]{preview}
 \pagestyle{empty}
 \begin{document}
@@ -35,7 +35,7 @@ __REPLACE_ME__ %this is where your LaTeX expression goes
     </p>
     <p>
     The file is written as UTF-8 (always) so please do not remove the
-    <tt>utf8x</tt> encoding.
+    <tt>utf8</tt> encoding.
     </p>
     <h1>Alternative templates</h1>
     <p>
@@ -46,7 +46,7 @@ __REPLACE_ME__ %this is where your LaTeX expression goes
     </p>
     <pre>
 \documentclass{article}
-\usepackage[utf8x]{inputenc}
+\usepackage[utf8]{inputenc}
 \usepackage[active,displaymath,textmath]{preview}
 \usepackage{amsmath,amssymb,amsopn}
 \usepackage{mathrsfs}

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -4,6 +4,6 @@ pref("tblatex.autodpi", true);
 pref("tblatex.font_px", 16);
 pref("tblatex.log", true);
 pref("tblatex.debug", false);
-pref("tblatex.template", "\\documentclass{article}\n\\usepackage[utf8x]{inputenc}\n\\usepackage[active,displaymath,textmath]{preview}\n\\pagestyle{empty}\n\\begin{document}\n__REPLACE_ME__ %this is where your LaTeX expression goes\n\\end{document}\n");
+pref("tblatex.template", "\\documentclass{article}\n\\usepackage[utf8]{inputenc}\n\\usepackage[active,displaymath,textmath]{preview}\n\\pagestyle{empty}\n\\begin{document}\n__REPLACE_ME__ %this is where your LaTeX expression goes\n\\end{document}\n");
 pref("tblatex.firstrun", 0);
 


### PR DESCRIPTION
This removes the (Debian) dependency of package texlive-latex-extra (Bug #8).

BTW: Will the template be automatically updated? I also ask, because PR #53 renamed the placeholder from `__REPLACEME__` to `__REPLACE_ME__`, which would break the template, if it is not updated automatically...