### PR TITLE
Better descriptions [hopefully]

### DIFF
--- a/content/insert.js
+++ b/content/insert.js
@@ -32,7 +32,14 @@ var prefs = Components.classes["@mozilla.org/preferences-service;1"]
 
 function populate(template, selection) {
   var marker = "__REPLACE_ME__";
+  var oldmarker = "__REPLACEME__";
   var start = template.indexOf(marker);
+  if (start < 0) {
+    start = string.indexOf(oldmarker);
+    if (start > -1) {
+      marker = oldmarker;
+    } 
+  }
   if (start > -1 && selection) {
     // Replace marker with selection
     template = template.substring(0, start) + selection + template.substring(start+marker.length)

--- a/content/insert.xul
+++ b/content/insert.xul
@@ -11,8 +11,8 @@
     
     <dialogheader title="Latex It!" description="Insert a complex LaTeX expression"/>
     <groupbox>
-      <description>Edit the default document below and the visible parts will be
-      inserted in your message:</description>
+      <description>Edit the LaTeX document below, which will be run through LaTeX.
+        After which, the visible parts will be inserted in your message:</description>
       <html:textarea id="tblatex-expr" multiline="true" rows="24" />
     <hbox align="baseline">
       <checkbox id="autodpi-checkbox" oncommand="on_autodpi();"

--- a/content/main.js
+++ b/content/main.js
@@ -400,9 +400,9 @@ var tblatex = {
       // Look for old marker
       i = string.indexOf(oldmarker);
       if (i < 0) {
-        log += "\n!!! Could not find the place marker '" + marker + "' in your template.\n";
+        log += "\n!!! Could not find the placeholder '" + marker + "' in your template.\n";
         log += "This would be the place, where your LaTeX expression is inserted.\n";
-        log += "Please edit your template and add this marker.\n";
+        log += "Please edit your template and add this placeholder.\n";
         return [, log];
       } else {
         len = oldmarker.length;

--- a/content/options.xul
+++ b/content/options.xul
@@ -57,7 +57,7 @@
         onclick="window.openDialog('chrome://tblatex/content/help.html', '',
           'all,chrome,dialog=no,status,toolbar,width=640,height=480');" />
     </hbox>
-    <description>Use __REPLACE_ME__ as a place marker for your LaTeX expression.</description>
+    <description>Use __REPLACE_ME__ as a placeholder for your LaTeX expression.</description>
     <html:textarea preference="tblatex.template" id="template_textbox" multiline="true"
       rows="12" />
   </groupbox>

--- a/content/options.xul
+++ b/content/options.xul
@@ -57,7 +57,7 @@
         onclick="window.openDialog('chrome://tblatex/content/help.html', '',
           'all,chrome,dialog=no,status,toolbar,width=640,height=480');" />
     </hbox>
-    <description>Use __REPLACE_ME__ as a place marker, if you want to have it automatically highlighted.</description>
+    <description>Use __REPLACE_ME__ as a place marker for your LaTeX expression.</description>
     <html:textarea preference="tblatex.template" id="template_textbox" multiline="true"
       rows="12" />
   </groupbox>


### PR DESCRIPTION
When testing, I noticed that the descriptions for the textboxes containing the LaTeX documents were a bit confusing (at least for me):
- Changed description of LaTeX document in 'Insert complex LaTeX expression'.
- Changed description of the template's textbox in configuration.

Maybe you have a better idea?

I also wanted to make the description in the 'Insert complex LaTeX expression' to word-wrap automatically to the (minimum) width of the dialog box, but could not find how to do it.

I found, how to hard-wrap it:
https://stackoverflow.com/questions/10031215/br-or-newline-in-xul#answer-10032938
but this is far from ideal.

Any ideas?