### PR TITLE
Improvements to the template with regard to inserting complex LaTeX

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,7 @@
 --vX.Y.Z
 
 - Fixed baseline alignment on multiple runs (Bug #64).
+- Bracket the placeholder with $$ in the complex LaTeX dialog.
 - Added option to keep the temporary files, even after successful LaTeX runs.
 
 --v0.7.2

--- a/content/help.html
+++ b/content/help.html
@@ -20,7 +20,7 @@
 \usepackage[active,displaymath,textmath]{preview}
 \pagestyle{empty}
 \begin{document}
-__REPLACE_ME__ %this is where your LaTeX expression goes
+__REPLACE_ME__ % this is where your LaTeX expression goes between $$
 \end{document}
     </pre>
    <p>
@@ -54,7 +54,7 @@ __REPLACE_ME__ %this is where your LaTeX expression goes
 \usepackage{mathpazo}
 \pagestyle{empty}
 \begin{document}
-__REPLACE_ME__ %this is where your LaTeX expression goes
+__REPLACE_ME__ % this is where your LaTeX expression goes between $$
 \end{document}
     </pre>
  

--- a/content/insert.js
+++ b/content/insert.js
@@ -40,11 +40,17 @@ function populate(template, selection) {
       marker = oldmarker;
     }
   }
-  if (start > -1 && selection) {
-    // Replace marker with selection
-    template = template.substring(0, start) + selection + template.substring(start+marker.length)
-    marker = selection;
-  }
+  if (start > -1)
+    if (selection) {
+      // Replace marker with selection
+      template = template.substring(0, start) + selection + template.substring(start+marker.length)
+      marker = selection;
+    }
+    else {
+      // Insert $ on either side of the marker, so it's easier for the user
+      template = template.slice(0, start) + "$" + template.slice(start, start+marker.length) + "$" + template.slice(start+marker.length);
+       start += 1
+    }
 
   var textarea = document.getElementById("tblatex-expr");
   textarea.value = template;

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -5,6 +5,6 @@ pref("tblatex.font_px", 16);
 pref("tblatex.log", true);
 pref("tblatex.debug", false);
 pref("tblatex.keeptempfiles", false);
-pref("tblatex.template", "\\documentclass{article}\n\\usepackage[utf8]{inputenc}\n\\usepackage[active,displaymath,textmath]{preview}\n\\pagestyle{empty}\n\\begin{document}\n__REPLACE_ME__ %this is where your LaTeX expression goes\n\\end{document}\n");
+pref("tblatex.template", "\\documentclass{article}\n\\usepackage[utf8]{inputenc}\n\\usepackage[active,displaymath,textmath]{preview}\n\\pagestyle{empty}\n\\begin{document}\n__REPLACE_ME__ % this is where your LaTeX expression goes between $$\n\\end{document}\n");
 pref("tblatex.firstrun", 0);
 


### PR DESCRIPTION
When looking into inserting complex LaTeX, I noticed that I was not aware, that only the part between `$$` gets inserted. So I put two reminders into the add-on:

1. A hint in the template itself, that the mathematical expression has to be put between `$$`.
2. Automatically bracket the placeholder whenever the Insert complex LaTeX dialog box is opened.