### PR TITLE
Colored text and transparent background.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -3,7 +3,7 @@
 - Improvements in the generated .png bitmaps: Transparent background
   (if not set otherwise in LaTeX document) and compression level 3.
 - Color of bitmap is now color of surrounding text. (A color specification
-  in the the LaTeX file gets always the priority).
+  in the the LaTeX file gets always the priority). (Bug #70)
 - Layout improvements in configuration dialog.
 
 --v0.7.2

--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,12 @@
---vX.Y.Z
+--v0.7.3
+
+- Improvements in the generated .png bitmaps: Transparent background
+  (if not set otherwise in LaTeX document) and compression level 3.
+- Color of bitmap is now color of surrounding text. (A color specification
+  in the the LaTeX file gets always the priority).
+- Layout improvements in configuration dialog.
+
+--v0.7.2
 
 - Fixed baseline alignment on multiple runs (Bug #64).
 - Check for inclusion of "preview" package in LaTeX template (Bug #63).

--- a/content/options.xul
+++ b/content/options.xul
@@ -28,34 +28,40 @@
   <separator />
   <groupbox>
     <label value="Configurations:" style="header; font-weight: bold;" />
-    <hbox>
-      <checkbox preference="tblatex.autodpi" id="autodpi_checkbox"
-        label="Adapt image resolution automatically to font size" />
-    </hbox>
-    <hbox align="baseline">
-      <label control="fontpx_textbox" value="Font size of image, if not automatically set:" />
-      <textbox preference="tblatex.font_px" id="fontpx_textbox"
-        type="number" min="1" decimalplaces="0" increment="1" size="2" />
-      <label control="fontpx_textbox" value="px" />
-    </hbox>
-    <hbox>
-      <checkbox preference="tblatex.log" id="log_checkbox" oncommand="on_log();"
-        label="Generate a log report" />
-    </hbox>
-    <hbox>
-      <checkbox preference="tblatex.debug" id="debug_checkbox"
-        label="Generate debug info" />
-    </hbox>
-    <hbox>
-      <checkbox preference="tblatex.keeptempfiles" id="keeptempfiles_checkbox"
-        label="Keep generated files" />
-    </hbox>
+    <groupbox>
+      <label value="Appearance:" style="header;" />
+      <hbox>
+        <checkbox preference="tblatex.autodpi" id="autodpi_checkbox"
+          label="Adapt image resolution automatically to font size" />
+      </hbox>
+      <hbox align="baseline">
+        <label control="fontpx_textbox" value="Font size of image, if not automatically set:" />
+        <textbox preference="tblatex.font_px" id="fontpx_textbox"
+          type="number" min="1" decimalplaces="0" increment="1" size="2" />
+        <label control="fontpx_textbox" value="px" />
+      </hbox>
+    </groupbox>
+    <groupbox>
+      <label value="Debugging:" style="header;" />
+      <hbox>
+        <checkbox preference="tblatex.log" id="log_checkbox" oncommand="on_log();"
+          label="Generate a log report" />
+      </hbox>
+      <hbox>
+        <checkbox preference="tblatex.debug" id="debug_checkbox"
+          label="Generate debug info" />
+      </hbox>
+      <hbox>
+        <checkbox preference="tblatex.keeptempfiles" id="keeptempfiles_checkbox"
+          label="Keep generated files" />
+      </hbox>
+    </groupbox>
   </groupbox>
   <separator />
   <groupbox>
     <label value="Template:" style="header; font-weight: bold;" />
     <hbox>
-      <label control="template_textbox" value="Template to use to generate LaTeX parts."/>
+      <label control="template_textbox" value="Template to be used to generate LaTeX parts."/>
       <spacer flex="1" />
       <label style="text-decoration: underline; color: navy; cursor: pointer" value="Help ?"
         onclick="window.openDialog('chrome://tblatex/content/help.html', '',


### PR DESCRIPTION
I just noticed, that `dvipng` can do transparent backgrounds and coloured text. This PR adds these features (and closes #70).

I don't think, that these new features have to be made configurable, because colours specified in the LaTeX document always take precedence over these two settings.

And I improved the configuration dialog a tiny bit by categorizing the appearance and debugging options …