### PR TITLE
Check for preview package suddenly failed

### DIFF
--- a/content/main.js
+++ b/content/main.js
@@ -118,7 +118,7 @@ var tblatex = {
       // introduced in v0.7.x.
       //
       // If the package(s) cannot be found, an alert message window is shown, informing the user.
-      var re = /^[^%]*\\usepackage\[(.*,\s*)?active(,.*)?\]{(.*,\s*)?preview(,.*)?}/;
+      var re = /^[^%]*\\usepackage\[(.*,\s*)?active(,.*)?\]{(.*,\s*)?preview(,.*)?}/m;
       var package_match = latex_expr.match(re);
       if (!package_match) {
         alert("Latex It! Error - Nothing added!\n\nThe package 'preview' cannot be found in the LaTeX file.\nThe inclusion of the LaTeX package 'preview' (with option 'active') is mandatory for the generated pictures to be aligned with the surrounding text!\n\nSolution:\n\tInsert a line with\n\t\t\\usepackage[active,displaymath,textmath]{preview}\n\tin the preamble of your LaTeX template or complex expression.");


### PR DESCRIPTION
Today I wanted to write a mail with a mathematical expression and suddenly I got the error message, that the `preview` package was not included. This PR should fix it (but I have no idea, why it used to work before …)