### PR TITLE
Fixes the process calls with nsIProcess on Windows

### DIFF
--- a/content/main.js
+++ b/content/main.js
@@ -150,13 +150,13 @@ var tblatex = {
         return process;
       }
       var sanitize_arg = function(arg) {
-		// on Windows the nsIProcess function will add quotes around all arguments with spaces for us
-		if (isWindows)
-			return arg;
-		else if (arg.indexOf(" ") < 0)
-			return arg;
-		else
-			return "\""+arg+"\"";
+        // on Windows the nsIProcess function will add quotes around all arguments with spaces for us
+        if (isWindows)
+          return arg;
+        else if (arg.indexOf(" ") < 0)
+          return arg;
+        else
+          return "\""+arg+"\"";
       }
       
       var latex_bin = init_file(prefs.getCharPref("latex_path"));
@@ -244,8 +244,8 @@ var tblatex = {
 
       var latex_process = init_process(latex_bin);
       var latex_args = ["-output-directory="+temp_dir, "-interaction=batchmode", temp_file.path];
-	  // This adds quotes around all arguments that contains spaces but only on Unix (on Windows the nsIProcess function will add quotes around all arguments with spaces for us)
-	  latex_args = latex_args.map(sanitize_arg);
+      // This adds quotes around all arguments that contains spaces but only on Unix (on Windows the nsIProcess function will add quotes around all arguments with spaces for us)
+      latex_args = latex_args.map(sanitize_arg);
       latex_process.run(true, latex_args, latex_args.length);
       if (debug)
         log += "I ran "+sanitize_arg(latex_bin.path)+" "+latex_args.join(" ")+" error code "+latex_process.exitValue+"\n";
@@ -343,19 +343,18 @@ var tblatex = {
         log += "*** Calculated resolution is "+dpi+" dpi\n";
 
       var shell_process = init_process(shell_bin);
-	  // The additional echo commands are needed on Windows in order to remove the unwanded backslaches and quotes added by the nsIProcess function ( shell_process.run )
-	  if (isWindows) {
-		var prefix_args = ["echo ", "\"", "&"];
-		var suffix_args = ["&", "echo", "\""];
-	  } else {
-		var prefix_args = ["\""];
-		var suffix_args = ["\""];
-	  }
-	  var dvipng_args = [dvipng_bin.path, "--depth", "-T", "tight", "-z", "3", "-bg", "Transparent", "-D", dpi.toString(), "-fg", font_color, "-o", png_file.path, dvi_file.path, ">", depth_file.path];
-	  // This adds quotes around all arguments that contains spaces but only on Unix (on Windows the nsIProcess function will add quotes around all arguments with spaces for us)
-	  dvipng_args = dvipng_args.map(sanitize_arg);
-	  var process_args = [shell_option].concat(prefix_args, dvipng_args, suffix_args);
-	  shell_process.run(true, process_args, process_args.length);
+      var dvipng_args = [dvipng_bin.path, "--depth", "-T", "tight", "-z", "3", "-bg", "Transparent", "-D", dpi.toString(), "-fg", font_color, "-o", png_file.path, dvi_file.path, ">", depth_file.path];
+      // This adds quotes around all arguments that contains spaces but only on Unix (on Windows the nsIProcess function will add quotes around all arguments with spaces for us)
+      dvipng_args = dvipng_args.map(sanitize_arg);
+      if (isWindows) {
+        // The additional echo commands are needed on Windows in order to remove the unwanded backslaches and quotes added by the nsIProcess function ( shell_process.run )
+        var prefix_args = ["echo ", "\"", "&"];
+        var suffix_args = ["&", "echo", "\""];
+        var process_args = [shell_option].concat(prefix_args, dvipng_args, suffix_args);
+      } else {
+        var process_args = [shell_option, dvipng_args.join(" ")];
+      }
+      shell_process.run(true, process_args, process_args.length);
       if (deletetempfiles) dvi_file.remove(false);
       if (debug)
         log += "I ran "+shell_bin.path+" -c '"+dvipng_args.join(" ")+"'\n";

--- a/content/main.js
+++ b/content/main.js
@@ -149,11 +149,14 @@ var tblatex = {
         process.init(path);
         return process;
       }
-      var sanitize_path = function(path) {
-        if (path.indexOf(" ") < 0)
-            return path;
-        else
-            return "\""+path+"\"";
+      var sanitize_arg = function(arg) {
+		// on Windows the nsIProcess function will add quotes around all arguments with spaces for us
+		if (isWindows)
+			return arg;
+		else if (arg.indexOf(" ") < 0)
+			return arg;
+		else
+			return "\""+arg+"\"";
       }
       
       var latex_bin = init_file(prefs.getCharPref("latex_path"));
@@ -240,10 +243,12 @@ var tblatex = {
 
 
       var latex_process = init_process(latex_bin);
-      var latex_args = ["-output-directory="+sanitize_path(temp_dir), "-interaction=batchmode", sanitize_path(temp_file.path)];
+      var latex_args = ["-output-directory="+temp_dir, "-interaction=batchmode", temp_file.path];
+	  // This adds quotes around all arguments that contains spaces but only on Unix (on Windows the nsIProcess function will add quotes around all arguments with spaces for us)
+	  latex_args = latex_args.map(sanitize_arg);
       latex_process.run(true, latex_args, latex_args.length);
       if (debug)
-        log += "I ran "+sanitize_path(latex_bin.path)+" "+latex_args.join(" ")+" error code "+latex_process.exitValue+"\n";
+        log += "I ran "+sanitize_arg(latex_bin.path)+" "+latex_args.join(" ")+" error code "+latex_process.exitValue+"\n";
       if (latex_process.exitValue) {
         st = 1;
         log += "LaTeX process returned "+latex_process.exitValue+"\nProceeding anyway...\n";
@@ -338,8 +343,19 @@ var tblatex = {
         log += "*** Calculated resolution is "+dpi+" dpi\n";
 
       var shell_process = init_process(shell_bin);
-      var dvipng_args = [sanitize_path(dvipng_bin.path), "--depth", "-T", "tight", "-z", "3", "-bg", "Transparent", "-D", dpi, "-fg", "\""+font_color+"\"", "-o", sanitize_path(png_file.path), sanitize_path(dvi_file.path), ">", sanitize_path(depth_file.path)];
-      shell_process.run(true, [shell_option, dvipng_args.join(" ")], 2);
+	  // The additional echo commands are needed on Windows in order to remove the unwanded backslaches and quotes added by the nsIProcess function ( shell_process.run )
+	  if (isWindows) {
+		var prefix_args = ["echo ", "\"", "&"];
+		var suffix_args = ["&", "echo", "\""];
+	  } else {
+		var prefix_args = ["\""];
+		var suffix_args = ["\""];
+	  }
+	  var dvipng_args = [dvipng_bin.path, "--depth", "-T", "tight", "-z", "3", "-bg", "Transparent", "-D", dpi.toString(), "-fg", font_color, "-o", png_file.path, dvi_file.path, ">", depth_file.path];
+	  // This adds quotes around all arguments that contains spaces but only on Unix (on Windows the nsIProcess function will add quotes around all arguments with spaces for us)
+	  dvipng_args = dvipng_args.map(sanitize_arg);
+	  var process_args = [shell_option].concat(prefix_args, dvipng_args, suffix_args);
+	  shell_process.run(true, process_args, process_args.length);
       if (deletetempfiles) dvi_file.remove(false);
       if (debug)
         log += "I ran "+shell_bin.path+" -c '"+dvipng_args.join(" ")+"'\n";


### PR DESCRIPTION
When there where spaces in the arguments of the process calls:
    -`latex_process.run`
    -`shell_process.run`
`nsIProcess` would add additional quotes around the arguments causing the process to fail.

This fix should work on both Unix and Windows but I only tested it in Windows. It should also be tested on Unix, to make sure it still works there. (Closes #74)