### PR TITLE
Move extra functions into notifyTools.js

### DIFF
--- a/api/WindowListener/schema.json
+++ b/api/WindowListener/schema.json
@@ -5,26 +5,26 @@
       {
         "name": "onNotifyBackground",
         "type": "function",
-        "description": "Fired when a new notification for 'WindowListenerNotifyBackgroundObserver' has been received with aData matching the ID of this extension. Only one listener is supported.",
+        "description": "Fired when a new notification from notifyTools.js in an Experiment has been received.",
         "parameters": [
           {
-            "name": "info",
+            "name": "data",
             "type": "any",
-            "description": "Info object passed into notifyObserver as aSubject and forwarded to the listener. Restrictions of the structured clone algorythm apply."
+            "description": "Restrictions of the structured clone algorythm apply."
           }
         ]
       }
     ],
     "functions": [
       {
-        "name": "notifyLegacy",
+        "name": "notifyExperiment",
         "type": "function",
-        "description": "Notifies the 'WindowListenerNotifyLegacyObserver' and passes and uses the provided info object as aSubject for notifyObserver and the add-on ID as aData.",
+        "description": "Notifies notifyTools.js in an Experiment and sends data.",
         "parameters": [
           {
-            "name": "info",
+            "name": "data",
             "type": "any",
-            "description": "Info object forwarded to the observer. The value will be in aSubject.wrappedJSObject. Restrictions of the structured clone algorythm apply."
+            "description": "Restrictions of the structured clone algorythm apply."
           }
         ]
       },

--- a/background.js
+++ b/background.js
@@ -16,7 +16,6 @@ messenger.runtime.onMessage.addListener((info, sender) => {
   }
 });
 
-
 /*
  * Register a onNotify listener to catch messages send from privileged scope.
 */
@@ -24,20 +23,15 @@ messenger.WindowListener.onNotifyBackground.addListener((info) => {
   switch (info.command) {
     case "openFirstRunTab":
       openFirstRunTab();
-      // I used LatexIt to implement and test these functions. Left it in as
-      // a working example for ping-pong communication.
-      messenger.WindowListener.notifyLegacy(info);
       break;
   }
 });
-
 
 function openFirstRunTab() {
   messenger.tabs.create({
     url: "content/firstrun.html"
   });
 }
-
 
 (async () => { 
   messenger.WindowListener.registerDefaultPrefs(
@@ -69,4 +63,3 @@ function openFirstRunTab() {
   }
   
 })();
-

--- a/content/notifyTools.js
+++ b/content/notifyTools.js
@@ -1,0 +1,55 @@
+const ADDON_ID = "tblatex@xulforum.org";
+
+var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+
+var notifyTools = {
+  registeredCallbacks: {},
+  registeredCallbacksNextId: 1,
+  
+  onNotifyExperimentObserver: {
+    observe: async function (aSubject, aTopic, aData) {
+      if (ADDON_ID == "") {
+        throw new Error("notifyTools: ADDON_ID is empty!");
+      }
+      if (aData != ADDON_ID) {
+        return;
+      }
+      // The data has been stuffed in an array so simple strings can be used as
+      // payload without the observerService complaining.
+      let [data] = aSubject.wrappedJSObject;
+      for (let registeredCallback of Object.values(notifyTools.registeredCallbacks)) {
+        registeredCallback(data);
+      }
+    }
+  },
+
+  registerListener: function (listener) {
+    let id = this.registeredCallbacksNextId++;
+    this.registeredCallbacks[id] = listener;
+    return id;
+  },
+
+  removeListener: function (id) {
+    delete this.registeredCallbacks[id];
+  },
+
+  notifyBackground: function (data) {
+    if (ADDON_ID == "") {
+      throw new Error("notifyTools: ADDON_ID is empty!");
+    }
+    return new Promise(resolve => {
+    Services.obs.notifyObservers(
+      {data, resolve},
+      "WindowListenerNotifyBackgroundObserver",
+      ADDON_ID
+    );
+    });
+  }
+}
+
+window.addEventListener("load", function (event) {
+  Services.obs.addObserver(notifyTools.onNotifyExperimentObserver, "WindowListenerNotifyExperimentObserver", false);
+  window.addEventListener("unload", function (event) {
+  Services.obs.removeObserver(notifyTools.onNotifyExperimentObserver, "WindowListenerNotifyExperimentObserver");
+  }, false);
+}, false);

--- a/content/options.js
+++ b/content/options.js
@@ -1,22 +1,3 @@
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
-// I used LatexIt to implement and test these functions. Left it in as
-// a working example for ping-pong communication.
-let onNotifyLegacyObserver = {
- observe: function (aSubject, aTopic, aData) {
-   if (aData != "tblatex@xulforum.org") {
-     return;
-   }
-   console.log(aSubject.wrappedJSObject);
- }
-}
-window.addEventListener("load", function (event) {
-  Services.obs.addObserver(onNotifyLegacyObserver, "WindowListenerNotifyLegacyObserver", false);
-  window.addEventListener("unload", function (event) {
-    Services.obs.removeObserver(onNotifyLegacyObserver, "WindowListenerNotifyLegacyObserver");
-  }, false);
-}, false);
-
 function pick_file(pref, title) {
   var nsIFilePicker = Components.interfaces.nsIFilePicker;
   var fp = Components.classes["@mozilla.org/filepicker;1"].createInstance(nsIFilePicker);
@@ -30,12 +11,8 @@ function pick_file(pref, title) {
   });
 }
 
-function open_autodetect() {
-  // Notify WebExtension Background to open the first run tab.
-  Services.obs.notifyObservers(
-    {command: "openFirstRunTab"},
-    "WindowListenerNotifyBackgroundObserver",
-    "tblatex@xulforum.org");
+async function open_autodetect() {
+  notifyTools.notifyBackground({command: "openFirstRunTab"});
 }
 
 window.addEventListener("load", function (event) {

--- a/content/options.xhtml
+++ b/content/options.xhtml
@@ -8,6 +8,7 @@
   xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
   xmlns:html="http://www.w3.org/1999/xhtml"
 >
+  <script type="application/javascript" src="chrome://tblatex/content/notifyTools.js" />
   <script type="application/javascript" src="chrome://tblatex/content/options.js" />
  
   <groupbox>


### PR DESCRIPTION
I am sorry that you had to be the playground for this, but working on LatexIt gave me a couple of new ideas to make add-on updates more simple. I improved the notification system and updated the WL API and moved additional code directly related to the notification system into a notifyTools.js.

If you are interested, in a few hours/days you will find detailed information about the new notification system here:
https://github.com/thundernest/addon-developer-support/tree/master/scripts/notifyTools