### PR TITLE
Add option to set the temporary directory path on Windows. Also a few smaller changes.

### DIFF
--- a/api/LatexIt/implementation.js
+++ b/api/LatexIt/implementation.js
@@ -72,6 +72,14 @@ var LatexIt = class extends ExtensionCommon.ExtensionAPI {
             }
           }
           
+          if (isWindows) {
+            var temp_dir = Cc["@mozilla.org/file/directory_service;1"].
+              getService(Ci.nsIProperties).get("TmpD", Ci.nsIFile).path;
+            if (temp_dir.length > 0 && init_file(temp_dir).exists()) {
+              found.temp = temp_dir;
+            }
+          }
+
           return found;
         }
 

--- a/content/firstrun.html
+++ b/content/firstrun.html
@@ -27,7 +27,7 @@
       "autodetect again" at the bottom of the page once you're done with the
       setup.
     </p>
-    <div id="div_win32" style="display: none;">
+    <div class="windows_only" style="display: none">
       <h2>Attention!</h2>
       <p>
       It appears you are running Microsoft Windows.
@@ -54,6 +54,19 @@
       <li>LaTeX: <span id="latex_path"></span>&nbsp;<img id="latex_icon" src="exclamation.png" /></li>
       <li>dvipng: <span id="dvipng_path"></span>&nbsp;<img id="dvipng_icon" src="exclamation.png" /></li>
     </ul>
+    <div class="windows_only" style="display: none">
+      <p>
+        Temporary directory:
+      </p>
+      <ul>
+        <li>
+          <span id="temp_path"></span>&nbsp;<img id="temp_icon" src="exclamation.png" />
+          <div style="margin-top: 0.5em">
+            If this path contains <i>short filenames</i> (<i>SFN</i>, also called <i>8.3 filenames</i>) and LaTeX compilation fails, try setting it manually using only <i>long filenames</i> (<i>LFN</i>). MiKTeX does no longer support <i>short filenames</i>.
+          </div>
+        </li>
+      </ul>
+    </div>
     <span id="autodetect_report"></span>
     <p><strong><u>Are these settings correct?</u></strong></p>
     <p>

--- a/content/firstrun.js
+++ b/content/firstrun.js
@@ -26,7 +26,7 @@ async function on_load() {
   }
 
   var latex_path = await messenger.LegacyPrefs.getPref("tblatex.latex_path");
-  if (latex_path.length > 0 && messenger.LatexIt.file_exists(latex_path)) {
+  if (latex_path.length > 0 && await messenger.LatexIt.file_exists(latex_path)) {
     document.getElementById("latex_path").appendChild(document.createTextNode(latex_path));
     document.getElementById("latex_icon").src = "accept.png";
   } else {
@@ -34,7 +34,7 @@ async function on_load() {
     document.getElementById("button_yes").setAttribute("disabled", "disabled");
   }
   var dvipng_path =  await messenger.LegacyPrefs.getPref("tblatex.dvipng_path");
-  if (dvipng_path.length > 0 && messenger.LatexIt.file_exists(dvipng_path)) {
+  if (dvipng_path.length > 0 && await messenger.LatexIt.file_exists(dvipng_path)) {
     document.getElementById("dvipng_path").appendChild(document.createTextNode(dvipng_path));
     document.getElementById("dvipng_icon").src = "accept.png";
   } else {

--- a/content/firstrun.js
+++ b/content/firstrun.js
@@ -5,7 +5,8 @@ async function on_load() {
   let isOSX = (plattform.os == "mac");
   
   if (isWindows) {
-    document.getElementById("div_win32").style.display = "block";
+    document.querySelectorAll(".windows_only")
+      .forEach(e => e.style.display = "block");
   }
   
   if (isOSX) {
@@ -40,6 +41,21 @@ async function on_load() {
   } else {
     document.getElementById("dvipng_path").innerHTML = "<span style='color: #EB887C; font-weight: bold;'>Not Found!</span>";
     document.getElementById("button_yes").setAttribute("disabled", "disabled");
+  }
+
+  if (isWindows) {
+    var temp_path = await messenger.LegacyPrefs.getPref("tblatex.windows_temp_path");
+    if (temp_path.length == 0 || !(await messenger.LatexIt.file_exists(temp_path))) {
+      temp_path = found.temp || "";
+      await messenger.LegacyPrefs.setPref("tblatex.windows_temp_path", temp_path);
+    }
+    if (temp_path) {
+      document.getElementById("temp_path").appendChild(document.createTextNode(temp_path));
+      document.getElementById("temp_icon").src = "accept.png";
+    } else {
+      document.getElementById("temp_path").innerHTML = "<span style='color: #EB887C; font-weight: bold;'>Not Found!</span>";
+      document.getElementById("button_yes").setAttribute("disabled", "disabled");
+    }
   }
 }
 

--- a/content/main.js
+++ b/content/main.js
@@ -147,6 +147,7 @@ var tblatex = {
       var init_process = function(path) {
         var process = Components.classes["@mozilla.org/process/util;1"].createInstance(Components.interfaces.nsIProcess);
         process.init(path);
+        process.startHidden = true;
         return process;
       }
       var sanitize_arg = function(arg) {

--- a/content/main.js
+++ b/content/main.js
@@ -204,14 +204,15 @@ var tblatex = {
                   .getService(Components.interfaces.nsIEnvironment);
         var shell_bin = init_file(env.get("COMSPEC"));
         var shell_option = "/C";
+        var temp_dir = prefs.getCharPref("windows_temp_path");
       } else {
         var shell_bin = init_file("/bin/sh");
         var shell_option = "-c";
+        var temp_dir = Components.classes["@mozilla.org/file/directory_service;1"].
+          getService(Components.interfaces.nsIProperties).
+          get("TmpD", Components.interfaces.nsIFile).path;
       }
 
-      var temp_dir = Components.classes["@mozilla.org/file/directory_service;1"].
-        getService(Components.interfaces.nsIProperties).
-        get("TmpD", Components.interfaces.nsIFile).path;
       temp_file = init_file(temp_dir);
       temp_file.append("tblatex-"+g_suffix+".png");
       while (temp_file.exists()) {

--- a/content/options.js
+++ b/content/options.js
@@ -20,7 +20,7 @@ window.addEventListener("load", function (event) {
 function pick_file(textboxId, title) {
   var nsIFilePicker = Components.interfaces.nsIFilePicker;
   var fp = Components.classes["@mozilla.org/filepicker;1"].createInstance(nsIFilePicker);
-  fp.init(window, "Select the "+title+" binary", nsIFilePicker.modeOpen);
+  fp.init(window, "Select the "+title, nsIFilePicker.modeOpen);
 
   fp.open(rv => {
     if( rv != nsIFilePicker.returnOK) {
@@ -38,10 +38,20 @@ function open_autodetect() {
     "tblatex@xulforum.org");
 }
 
-window.addEventListener("load", function (event) {
-  on_log();
-}, false);
-
 function on_log() {
   document.getElementById("debug_checkbox").disabled = !document.getElementById("log_checkbox").checked;
 }
+
+async function on_load() {
+
+  var isWindows = ("@mozilla.org/windows-registry-key;1" in Components.classes);
+
+  if (isWindows) {
+    document.querySelectorAll(".windows_only")
+      .forEach(e => e.style.display = "block");
+  }
+
+  on_log();
+}
+
+window.addEventListener("load", on_load, false);

--- a/content/options.js
+++ b/content/options.js
@@ -17,7 +17,7 @@ window.addEventListener("load", function (event) {
   }, false);
 }, false);
 
-function pick_file(pref, title) {
+function pick_file(textboxId, title) {
   var nsIFilePicker = Components.interfaces.nsIFilePicker;
   var fp = Components.classes["@mozilla.org/filepicker;1"].createInstance(nsIFilePicker);
   fp.init(window, "Select the "+title+" binary", nsIFilePicker.modeOpen);
@@ -26,7 +26,7 @@ function pick_file(pref, title) {
     if( rv != nsIFilePicker.returnOK) {
       return;
     }
-    pref.value = fp.file.path;
+    document.getElementById(textboxId).value = fp.file.path;
   });
 }
 

--- a/content/options.xhtml
+++ b/content/options.xhtml
@@ -15,12 +15,17 @@
     <hbox align="baseline">
       <label control="latex_textbox" value="Path to latex executable:" />
       <html:input preference="tblatex.latex_path" id="latex_textbox" />
-      <button label="Browse..." oncommand="pick_file('latex_textbox', 'latex');" />
+      <button label="Browse..." oncommand="pick_file('latex_textbox', 'latex binary');" />
     </hbox>
     <hbox align="baseline">
       <label control="dvipng_textbox" value="Path to dvipng executable:" />
       <html:input preference="tblatex.dvipng_path" id="dvipng_textbox" />
-      <button label="Browse..." oncommand="pick_file('dvipng_textbox', 'dvipng');" />
+      <button label="Browse..." oncommand="pick_file('dvipng_textbox', 'dvipng binary');" />
+    </hbox>
+    <hbox align="baseline" class="windows_only" style="display: none">
+      <label control="temp_textbox" value="Path to temporary directory:" />
+      <html:input preference="tblatex.windows_temp_path" id="temp_textbox" />
+      <button label="Browse..." oncommand="pick_file('temp_textbox', 'temporary directory');" />
     </hbox>
     <label style="text-decoration: underline; color: navy; cursor: pointer" value="Open the autodetection dialog"
       onclick="open_autodetect();" />

--- a/content/options.xhtml
+++ b/content/options.xhtml
@@ -37,7 +37,7 @@
       <hbox align="baseline">
         <label control="fontpx_textbox" value="Font size of image, if not automatically set:" />
         <html:input preference="tblatex.font_px" id="fontpx_textbox"
-          type="number" min="1" decimalplaces="0" increment="1" size="2" />
+          type="number" min="1" step="1" style="width: 6em" />
         <label control="fontpx_textbox" value="px" />
       </hbox>
     </groupbox>

--- a/content/options.xhtml
+++ b/content/options.xhtml
@@ -15,12 +15,12 @@
     <hbox align="baseline">
       <label control="latex_textbox" value="Path to latex executable:" />
       <html:input preference="tblatex.latex_path" id="latex_textbox" />
-      <button label="Browse..." oncommand="pick_file(document.getElementsByTagName('html:input')[0], 'latex');" />
+      <button label="Browse..." oncommand="pick_file('latex_textbox', 'latex');" />
     </hbox>
     <hbox align="baseline">
       <label control="dvipng_textbox" value="Path to dvipng executable:" />
       <html:input preference="tblatex.dvipng_path" id="dvipng_textbox" />
-      <button label="Browse..." oncommand="pick_file(document.getElementsByTagName('html:input')[1], 'dvipng');" />
+      <button label="Browse..." oncommand="pick_file('dvipng_textbox', 'dvipng');" />
     </hbox>
     <label style="text-decoration: underline; color: navy; cursor: pointer" value="Open the autodetection dialog"
       onclick="open_autodetect();" />

--- a/content/preferences.js
+++ b/content/preferences.js
@@ -1,6 +1,7 @@
 Preferences.addAll([
   { id: "tblatex.latex_path", type: "string" },
   { id: "tblatex.dvipng_path", type: "string" },
+  { id: "tblatex.windows_temp_path", type: "string" },
   { id: "tblatex.autodpi", type: "bool" },
   { id: "tblatex.font_px", type: "int" },
   { id: "tblatex.log", type: "bool" },

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -1,5 +1,6 @@
 pref("tblatex.latex_path", "");
 pref("tblatex.dvipng_path", "");
+pref("tblatex.windows_temp_path", "");
 pref("tblatex.autodpi", true);
 pref("tblatex.font_px", 16);
 pref("tblatex.log", true);


### PR DESCRIPTION
Hey,

I ran into the same issue as described in #15, #32 and #56 (even after #81 & #82). So I started digging and came up with a solution/workaround.

#### What's the problem?

As of May 2020, MiKTeX does no longer support short filenames (aka 8.3 filenames). Unfortunately in my case the path to the temporary directory as given by `Cc["@mozilla.org/file/directory_service;1"].getService(Ci.nsIProperties).get("TmpD", Ci.nsIFile).path` includes short filenames.
If I run the command that _LaTeX It!_ shows in the debug box manually (with the paths adjusted), everything works fine.

#### What I considered:

I tried finding a reasonable way to extract the full path in the given framework, but had no success:
- Use `Cc["@mozilla.org/process/environment;1"].createInstance(Ci.nsIEnvironment).get("TEMP"/"TMP")` instead, but it also contains short filenames.
- Use a different file or output stream interface that can return a reconstruction of the given path. I have found no such thing. I learned that `nsIFile` does not exactly represent a file (handle), but a _string_ (the path). As such, many of its properties and methods are just string manipulations. A notable exception is `exists()` which is indeed a true file operation.
- Use a shell script to construct and push the full path into a file or to the registry and get it from there. The shell script itself would be rather sophisticated (examples on StackOverflow) and the "solution" is so hacky that I didn't even try it.

Also, I haven't found a way to pass a working/execution directory to `nsIProcess`. Otherwise you could just launch the executables from the temporary directory.

#### What I came up with:

I added the option to change the path of the temporary directory. This setting is only used and shown on Windows.

During this I discovered a few other issues that I also tackled:
- Options: The contents of the `fontpx_textbox` are not displayed.
- Options: The file pickers are associated with the input boxes by order of appereance in the code, which might break if the code is restructured.
- Firstrun: The result of `async function file_exists()` is used in expressions without `await`. As the result is a promise, it is always true.
- Main: When compiling LaTeX on windows, multiple command windows pop open, but it should be a silent background process.

I tested my changes on:
- Windows 10 Pro (20H2), Thunderbird 78.10.1, MiKTeX 21.2
- Xubuntu 21.04, Thunderbird 78.8.1, TeX Live 2020

On these systems, everything seems to work fine. I don't have the possibility to test on OS X.

If some or all of these changes are desirable, please feel free to use them any way you like. Please tell me if you want this PR split up.

Max