### PR TITLE
Firstrun: Fix autodetect being successful unconditionally.

### DIFF
--- a/content/firstrun.js
+++ b/content/firstrun.js
@@ -26,7 +26,7 @@ async function on_load() {
   }
 
   var latex_path = await messenger.LegacyPrefs.getPref("tblatex.latex_path");
-  if (latex_path.length > 0 && messenger.LatexIt.file_exists(latex_path)) {
+  if (latex_path.length > 0 && await messenger.LatexIt.file_exists(latex_path)) {
     document.getElementById("latex_path").appendChild(document.createTextNode(latex_path));
     document.getElementById("latex_icon").src = "accept.png";
   } else {
@@ -34,7 +34,7 @@ async function on_load() {
     document.getElementById("button_yes").setAttribute("disabled", "disabled");
   }
   var dvipng_path =  await messenger.LegacyPrefs.getPref("tblatex.dvipng_path");
-  if (dvipng_path.length > 0 && messenger.LatexIt.file_exists(dvipng_path)) {
+  if (dvipng_path.length > 0 && await messenger.LatexIt.file_exists(dvipng_path)) {
     document.getElementById("dvipng_path").appendChild(document.createTextNode(dvipng_path));
     document.getElementById("dvipng_icon").src = "accept.png";
   } else {


### PR DESCRIPTION
The unresolved promise returned by file_exists() is used in expressions, which is meaningless as promises are truthy. Use the resolved promise value instead.