### PR TITLE
Options: Fix content of fontpx_textbox not being displayed.

### DIFF
--- a/content/options.xhtml
+++ b/content/options.xhtml
@@ -37,7 +37,7 @@
       <hbox align="baseline">
         <label control="fontpx_textbox" value="Font size of image, if not automatically set:" />
         <html:input preference="tblatex.font_px" id="fontpx_textbox"
-          type="number" min="1" decimalplaces="0" increment="1" size="2" />
+          type="number" min="1" step="1" style="width: 6em" />
         <label control="fontpx_textbox" value="px" />
       </hbox>
     </groupbox>


### PR DESCRIPTION
Inside the box arrows are rendered that presumably interfere with its text content. The size property is not meant for inputs of type number.

This updates the box's properties and sets a fixed width of 6em, which looks fine for 2-digit numbers on Windows and Linux.